### PR TITLE
feat: Implement basic parse_field function with unittests

### DIFF
--- a/responses/response.py
+++ b/responses/response.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC
 from typing import Optional
 
@@ -8,10 +9,32 @@ class Response(ABC):
             return any('response' in B.__dict__ for B in subclass.__mro__)
         return NotImplemented
 
-def parse_field(field: str, case_sensitive:bool=False, stop_str:Optional[str]=None) -> str:
+def parse_field(text: str, field: str, case_sensitive:bool=False, stop_str:Optional[str]=None) -> str:
     """
     Takes in the name of a field and returns the field corresponding to that string using regex
     regex parses starting from field until the optional stop_str
+    
+    Assumptions:
+    - The field will always be formatted as 'field_name: ' (e.g., 'command: ')
+    
+    :param text: The input string from which to extract the field.
     """
-    pass
+    # Define flags for case sensitivity
+    flags = 0 if case_sensitive else re.IGNORECASE
+
+    # Build the regular expression, with optional stop_str
+    if stop_str:
+        # Make stop_str optional using `|` (OR) to handle cases where it doesn't exist
+        regex = rf"{re.escape(field)}(.*?)(?:{re.escape(stop_str)}|$)"
+    else:
+        regex = rf"{re.escape(field)}(.*?)$"
+    
+    # Search the text using the regex
+    match = re.search(regex, text, flags)
+
+    # If the match was found, return the extracted field value
+    if match:
+        return match.group(1).strip()
+    
+    return ""
 

--- a/responses/response_test.py
+++ b/responses/response_test.py
@@ -1,0 +1,64 @@
+import unittest
+from response import parse_field
+
+class TestParseField(unittest.TestCase):
+    def test_basic_extraction(self):
+        """Test that a field is correctly extracted from the text."""
+        text = "command: run_this_script"
+        field = "command: "
+        expected = "run_this_script"
+        self.assertEqual(parse_field(text, field), expected)
+
+    def test_case_insensitivity(self):
+        """Test that the extraction works with case insensitivity."""
+        text = "COMMAND: run_this_script"
+        field = "command: "
+        expected = "run_this_script"
+        self.assertEqual(parse_field(text, field, case_sensitive=False), expected)
+
+    def test_case_sensitivity(self):
+        """Test that case sensitivity works as expected."""
+        text = "COMMAND: run_this_script"
+        field = "command: "
+        expected = ""
+        self.assertEqual(parse_field(text, field, case_sensitive=True), expected)
+
+    def test_stop_string(self):
+        """Test that extraction stops correctly when stop_str is provided."""
+        text = "command: run_this_script; observation: success"
+        field = "command: "
+        stop_str = ";"
+        expected = "run_this_script"
+        self.assertEqual(parse_field(text, field, stop_str=stop_str), expected)
+
+    def test_stop_string_not_found(self):
+        """Test that when stop_str is not found, it extracts until the end."""
+        text = "command: run_this_script observation: success"
+        field = "command: "
+        stop_str = ";"
+        expected = "run_this_script observation: success"
+        self.assertEqual(parse_field(text, field, stop_str=stop_str), expected)
+
+    def test_field_not_found(self):
+        """Test that an empty string is returned if the field is not found."""
+        text = "observation: success"
+        field = "command: "
+        expected = ""
+        self.assertEqual(parse_field(text, field), expected)
+
+    def test_empty_text(self):
+        """Test that an empty string is returned if the input text is empty."""
+        text = ""
+        field = "command: "
+        expected = ""
+        self.assertEqual(parse_field(text, field), expected)
+
+    def test_no_stop_str(self):
+        """Test that it extracts until the end if no stop_str is provided."""
+        text = "command: run_this_script observation: success"
+        field = "command: "
+        expected = "run_this_script observation: success"
+        self.assertEqual(parse_field(text, field), expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Added parse_field function to handle field extraction from a string.
- Assumes fields are formatted as 'field: ' and can be case-sensitive or not.
- Handles optional stop_str to stop parsing when stop_str is found.
- Includes unit tests for basic, edge case, and stop string scenarios.
- All tests pass.
