### PR TITLE
(Re)name branch to main

### DIFF
--- a/agents/patch_agent/patch_agent.py
+++ b/agents/patch_agent/patch_agent.py
@@ -230,7 +230,7 @@ class PatchAgent(BaseAgent):
     def cleanup(self):
         self.store_patch()
         
-        branch_name = "master"
+        branch_name = "main"
         try:
             subprocess.check_call(
                 ['git', 'checkout', branch_name], cwd=self.init_files.files_dir)

--- a/resources/init_files_resource.py
+++ b/resources/init_files_resource.py
@@ -96,6 +96,9 @@ class InitFilesResource(BaseResource):
                                cwd=work_dir, check=True)
                 logger.info(f"Initialized git repository in {work_dir}")
 
+                subprocess.run(["git", "branch", "-m", "main"], cwd=work_dir, check=True)
+                logger.info("Branch named to main")
+
                 subprocess.run(["git", "add", "."], cwd=work_dir, check=True)
 
                 subprocess.run(


### PR DESCRIPTION
Since some versions of Git have `main` as the initial branch instead of `master`, standardize the branch name to `main` when setting up the repo for original files.