### PR TITLE
fix next iteration

### DIFF
--- a/workflows/base_workflow.py
+++ b/workflows/base_workflow.py
@@ -241,6 +241,9 @@ class BaseWorkflow(ABC):
             if last_message.next:
                 last_message = await self.rerun_manager.run_edited(last_message)
                 return last_message
+            if last_message.parent and last_message.parent.next:
+                last_message = await self.rerun_manager.run_edited(last_message.parent)
+                return last_message
         return None
     
     async def edit_message(self, message: Message, new_message_data: str) -> Message:


### PR DESCRIPTION
If an action is edited in an agent message and `next` is clicked, the next iteration (agent) will be spawned from the edited point, regardless if further iterations have already been created.

Does not fix that later iterations are not disappeared in this case.