### PR TITLE
Add command hook for next iteration

### DIFF
--- a/frontend/src/components/WorkflowDashboard/WorkflowDashboard.jsx
+++ b/frontend/src/components/WorkflowDashboard/WorkflowDashboard.jsx
@@ -42,6 +42,21 @@ export const WorkflowDashboard = ({ selectedWorkflow, interactiveMode, onWorkflo
     }
   }, [workflowStatus, messages]);
 
+  // Next iteration via ctrl + enter
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+        event.preventDefault();
+        triggerNextIteration();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [selectedWorkflow]);
+  
   const triggerNextIteration = async () => {
     if (selectedWorkflow?.id) {
       setIsNextDisabled(true);


### PR DESCRIPTION
From this PR, we can trigger next iteration (equivalent to clicking `next` button in UI) via ctrl+enter / cmd+enter.
...
This PR does not automatically save/send message during editing (to be done in separate PR). If next iteration is triggered during editing a message before saving, it will trigger next based on the last saved version, not new (unsaved) changes