### PR TITLE
Add API key entry support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
     "start": "concurrently \"npm:server\" \"npm:frontend\"",
     "server": "python server.py",
     "frontend": "npm start --prefix frontend"
+  },
+  "dependencies": {
+    "react-scripts": "^5.0.1"
   }
 }

--- a/resources/model_resource/model_provider.py
+++ b/resources/model_resource/model_provider.py
@@ -2,6 +2,7 @@ import os
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List
+import time
 
 from dotenv import load_dotenv
 
@@ -39,9 +40,13 @@ class ModelProvider(ABC):
         # Raise an error if the API key is not set in the environment or .env file.
         if not key:
             if env_path.is_file():
-                raise ValueError(
-                    f"{env_var} is not set in the .env file or environment variables"
-                )
+                # Ask the user to write the key to the .env file.
+                while not key:
+                    print(f"{env_var} key not detected. Please write your API key to the .env file.")
+                    time.sleep(5)
+                    load_dotenv(dotenv_path=env_path, override=True)
+                    key = os.getenv(env_var)
+                print(f"{env_var} Key found in .env file.")
             else:
                 raise ValueError(
                     f"{env_var} is not set in environment variables and .env file not found at {env_path}"


### PR DESCRIPTION
### CLI workflow:
- If the required key is not found, simply ask user to fill out the key manually in `.env`. We can technically also ask user to `input()` the API key via CLI but the GUI is messy, and I was hoping to unify how we add/update API keys (via the `.env` file).

### Frontend workflow:
Added an API key selector which works as follows:
 - Reads the `.env` file for a list of existing API key/value pairs. If an API key already exists, the user can click on the reveal button to read/check the value.
<img width="659" alt="image" src="https://github.com/user-attachments/assets/beffadba-2b55-4ad3-bae3-dc011fbcaade" />
<img width="694" alt="Screenshot 2025-01-24 at 7 23 27 PM" src="https://github.com/user-attachments/assets/b4524522-b349-40c9-9e36-1de6a919c796" />

  - The user can provide a new API key or override the existing key by clicking the update button.
 
<img width="723" alt="image" src="https://github.com/user-attachments/assets/a87ac368-2d67-4da7-832d-5a98f6619111" />
<img width="371" alt="Screenshot 2025-01-24 at 7 24 05 PM" src="https://github.com/user-attachments/assets/0eee8946-fbde-4ab9-a4e4-0b03431bf6e0" />

I think we currently don't have a model <-> required API key name mapping? But once we have that we can implement a model selector and check if the required API key already exists. This should then prevent any missing API key issues.

Resolves #261 