### PR TITLE
remove pycache from patch agent

### DIFF
--- a/agents/patch_agent/patch_agent.py
+++ b/agents/patch_agent/patch_agent.py
@@ -219,7 +219,6 @@ class PatchAgent(BaseAgent):
                 cwd=directory_path,
                 check=False
             )
-            # You can also remove *.pyc files if necessary:
             subprocess.run(
                 ['git', 'rm', '--cached', '*.pyc'],
                 cwd=directory_path,


### PR DESCRIPTION
The purpose of this PR is to clean up pycache files so there are not issues when applying patch