### PR TITLE
Add port constraints to grouping parallel runs

### DIFF
--- a/tests/test_run_experiments.py
+++ b/tests/test_run_experiments.py
@@ -1,0 +1,178 @@
+import os
+
+import pytest
+
+from run_experiments import ExperimentRunner
+
+
+@pytest.fixture
+def runner():
+    class MockExperimentRunner(ExperimentRunner):
+        def _load_config(self, path):
+            return {"workflow_type": "dummy"}
+
+    return MockExperimentRunner("dummy_config.yaml", hold_terminals=False)
+
+
+def print_groups(groups):
+    print("\nGrouped tasks:")
+    for group, tasks in groups.items():
+        print(f"{group}: {tasks}")
+
+
+def test_real_directories(runner):
+    # Get the directory of the test file
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+
+    # Move up one directory to reach the parent of 'tests'
+    parent_dir = os.path.dirname(base_dir)
+
+    dirs = ["bountybench/astropy", "bountybench/lunary", "bountybench/open-webui"]
+
+    for dir in dirs:
+        full_path = os.path.join(parent_dir, dir)
+        ports = runner._get_ports(full_path)
+        print(f"\nPorts for {dir}: {ports}")
+
+    # Now test the ExperimentRunner's get_port method
+    task_groups = {
+        os.path.join(parent_dir, dir): [("cmd", [f"command for {dir}"])] for dir in dirs
+    }
+
+    result = runner.task_groups_port_constraints(task_groups)
+
+    print("\nGrouped tasks:")
+    for group, tasks in result.items():
+        print(f"{group}: {tasks}")
+
+    # Assertions
+    assert len(result) == 2, "Expected 2 groups due to conflict between lunary and "
+
+    # Check if lunary and open-webui are in the same group (they should be due to conflict)
+    lunary_group = None
+    open_webui_group = None
+    for group, tasks in result.items():
+        for task in tasks:
+            if "lunary" in task[1][0]:
+                lunary_group = group
+            if "open-webui" in task[1][0]:
+                open_webui_group = group
+
+    assert (
+        lunary_group == open_webui_group
+    ), "lunary and open-webui should be in the same group due to port conflict"
+    print(f"\nlunary and open-webui group: {lunary_group}")
+    print("lunary and open-webui are in the same group (conflict detected)")
+
+    # Check that astropy is in a different group
+    astropy_group = None
+    for group, tasks in result.items():
+        for task in tasks:
+            if "astropy" in task[1][0]:
+                astropy_group = group
+                break
+        if astropy_group:
+            break
+
+    assert (
+        astropy_group != lunary_group
+    ), "astropy should be in a different group from lunary and open-webui"
+    print(f"astropy group: {astropy_group}")
+    print("astropy is in a different group (no conflict with lunary/open-webui)")
+
+
+class MockExperimentRunner(ExperimentRunner):
+    def __init__(self):
+        self.port_map = {}
+
+    def _get_ports(self, task_dir):
+        return self.port_map.get(task_dir, [])
+
+
+@pytest.fixture
+def mock_runner():
+    return MockExperimentRunner()
+
+
+def print_groups(groups):
+    print("\nGrouped tasks:")
+    for group, tasks in groups.items():
+        print(f"{group}: {tasks}")
+
+
+def test_no_conflicts(mock_runner):
+    mock_runner.port_map = {
+        "task1": ["8000"],
+        "task2": ["9000"],
+        "task3": ["7000"],
+    }
+    task_groups = {
+        "task1": [("cmd1", ["command1"])],
+        "task2": [("cmd2", ["command2"])],
+        "task3": [("cmd3", ["command3"])],
+    }
+
+    result = mock_runner.task_groups_port_constraints(task_groups)
+    print_groups(result)
+
+    assert len(result) == 3
+    assert all(len(group) == 1 for group in result.values())
+
+
+def test_single_conflict(mock_runner):
+    mock_runner.port_map = {
+        "task1": ["8000"],
+        "task2": ["8000"],
+        "task3": ["7000"],
+    }
+    task_groups = {
+        "task1": [("cmd1", ["command1"])],
+        "task2": [("cmd2", ["command2"])],
+        "task3": [("cmd3", ["command3"])],
+    }
+
+    result = mock_runner.task_groups_port_constraints(task_groups)
+    print_groups(result)
+
+    assert len(result) == 2
+    assert any(len(group) == 2 for group in result.values())
+
+
+def test_multiple_conflicts(mock_runner):
+    mock_runner.port_map = {
+        "task1": ["8000"],
+        "task2": ["8000", "9000"],
+        "task3": ["9000"],
+        "task4": ["7000"],
+    }
+    task_groups = {
+        "task1": [("cmd1", ["command1"])],
+        "task2": [("cmd2", ["command2"])],
+        "task3": [("cmd3", ["command3"])],
+        "task4": [("cmd4", ["command4"])],
+    }
+
+    result = mock_runner.task_groups_port_constraints(task_groups)
+    print_groups(result)
+
+    assert len(result) == 2
+    assert any(len(group) == 3 for group in result.values())
+
+
+def test_no_ports(mock_runner):
+    mock_runner.port_map = {
+        "task1": [],
+        "task2": [],
+        "task3": [],
+    }
+    task_groups = {
+        "task1": [("cmd1", ["command1"])],
+        "task2": [("cmd2", ["command2"])],
+        "task3": [("cmd3", ["command3"])],
+    }
+
+    result = mock_runner.task_groups_port_constraints(task_groups)
+    print_groups(result)
+
+    assert len(result) == 3
+    assert all(len(group) == 1 for group in result.values())

--- a/utils/get_task_ports.py
+++ b/utils/get_task_ports.py
@@ -1,0 +1,99 @@
+import os
+
+import yaml
+
+
+def read_env_file(directory):
+    env_path = os.path.join(directory, ".env")
+    if not os.path.exists(env_path):
+        env_path = os.path.join(directory, "env")
+    env_vars = {}
+
+    if os.path.exists(env_path):
+        with open(env_path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    key, value = line.split("=", 1)
+                    env_vars[key.strip()] = value.strip()
+    return env_vars
+
+
+def get_localhosts(docker_compose_path):
+    try:
+        with open(docker_compose_path, "r") as f:
+            docker_compose = yaml.safe_load(f)
+
+        localhosts = set()
+        services = docker_compose.get("services", {})
+        env_vars = read_env_file(os.path.dirname(docker_compose_path))
+
+        for service in services.values():
+            ports = service.get("ports", [])
+            for port in ports:
+                if isinstance(port, str):
+                    parts = port.split(":")
+                    if len(parts) == 2:
+                        right_port = parts[1].split("/")[0]
+                    elif len(parts) == 1:
+                        right_port = parts[0].split("/")[0]
+                    else:
+                        continue
+
+                    # Check for environment variables
+                    if right_port.startswith("${") and right_port.endswith("}"):
+                        var_name = right_port[2:-1]
+                        if var_name in env_vars:
+                            right_port = env_vars[var_name]
+                        else:
+                            right_port = (
+                                f"${{{var_name}}}"  # Keep original if not found
+                            )
+
+                    localhosts.add(right_port)
+
+        return sorted(localhosts)
+    except Exception as e:
+        print(f"Error processing {docker_compose_path}: {str(e)}")
+        return []
+
+
+def find_docker_compose_files(base_dir):
+    for root, dirs, files in os.walk(base_dir):
+        if "codebase" in dirs:
+            dirs.remove("codebase")  # don't recurse into 'codebase' directory
+
+        for file in files:
+            if file in ["docker-compose.yml", "docker-compose.yaml"]:
+                yield os.path.join(root, file)
+
+
+def get_ports_for_directory(directory, print_names: bool = False):
+    all_localhosts = []
+    for docker_compose_path in find_docker_compose_files(directory):
+        localhosts = get_localhosts(docker_compose_path)
+        all_localhosts.extend(localhosts)
+
+        if print_names and localhosts:
+            # Get the relative path from the base directory
+            rel_path = os.path.relpath(os.path.dirname(docker_compose_path), directory)
+            if rel_path == ".":
+                rel_path = os.path.basename(directory)
+            print(f"{', '.join(localhosts)} - {rel_path}")
+
+    return all_localhosts
+
+
+def get_all_ports(print_names: bool = False):
+    # Get the directory of the script file
+    base_dir = "bountybench"
+    ports = get_ports_for_directory(base_dir, print_names)
+    print(ports)
+
+
+def main():
+    get_all_ports(True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds an additional grouping by port constraints to the parallel runs. Now a single task groups should include overlapping task dirs and/or (localhost) ports