### PR TITLE
Git actions: main or master

### DIFF
--- a/tests/utils/test_git_utils.py
+++ b/tests/utils/test_git_utils.py
@@ -8,6 +8,7 @@ import pytest
 from utils.git_utils import (
     git_apply_patch,
     git_checkout,
+    git_checkout_main,
     git_clean_untracked,
     git_commit,
     git_delete_branch,
@@ -102,7 +103,7 @@ def test_git_setup_dev_branch(tmp_git_repo):
     (tmp_git_repo / "file.txt").write_text("File for dev branch.")
     git_commit(tmp_git_repo, "Initial commit")
 
-    git_setup_dev_branch(tmp_git_repo, "master")  # Change to 'master' here
+    git_setup_dev_branch(tmp_git_repo)
     branches = subprocess.run(
         ["git", "branch"], cwd=tmp_git_repo, capture_output=True, text=True
     ).stdout
@@ -138,9 +139,8 @@ def test_git_delete_branch(tmp_git_repo):
     git_commit(tmp_git_repo, "Initial commit")
 
     subprocess.run(["git", "checkout", "-b", "test_branch"], cwd=tmp_git_repo)
-    subprocess.run(
-        ["git", "checkout", "master"], cwd=tmp_git_repo
-    )  # Switch to master before deletion
+    git_checkout_main(tmp_git_repo)  # Switch to main before deletion
+
     git_delete_branch(tmp_git_repo, "test_branch")
 
     result = subprocess.run(

--- a/utils/git_utils.py
+++ b/utils/git_utils.py
@@ -87,9 +87,33 @@ def git_checkout(directory_path: PathLike, commit: str, force=False) -> None:
         _run_git_command(directory, ["checkout", commit])
 
 
+def _get_main_branch(directory_path: PathLike):
+    directory = Path(directory_path)
+
+    # Get list of branches
+    result = _run_git_command(directory, ["branch", "--list"], capture_output=True)
+    branches = [
+        branch.strip().lstrip("*").strip()
+        for branch in result.stdout.split("\n")
+        if branch.strip()
+    ]
+
+    # Check for 'main' or 'master'
+    if "main" in branches:
+        branch_name = "main"
+    elif "master" in branches:
+        branch_name = "master"
+    else:
+        raise ValueError("Neither 'main' nor 'master' branch found in the repository.")
+
+    return branch_name
+
+
 def git_checkout_main(directory_path: PathLike, force=False) -> None:
-    """Checkout main branch."""
-    git_checkout(directory_path, "main", force)
+    """
+    Checkout main or master branch.
+    """
+    git_checkout(directory_path, _get_main_branch(directory_path), force)
 
 
 def git_clean_untracked(directory_path: PathLike) -> None:
@@ -248,9 +272,14 @@ def git_apply_patch(
         return False, msg
 
 
-def git_setup_dev_branch(directory_path: PathLike, commit: str = "main") -> None:
+def git_setup_dev_branch(
+    directory_path: PathLike, commit: Optional[str] = None
+) -> None:
     """Set up dev branch from specified commit."""
     directory = Path(directory_path)
+    if not commit:
+        commit = _get_main_branch(directory_path)
+
     try:
         # Verify valid repository
         result = _run_git_command(


### PR DESCRIPTION
This PR handles mixed usage of "main" vs "master" branch nomenclatures more gracefully.