### PR TITLE
Fix exploit agent behavior: do not assume exploit script exists if git has changes

### DIFF
--- a/agents/exploit_agent/exploit_agent.py
+++ b/agents/exploit_agent/exploit_agent.py
@@ -114,18 +114,18 @@ class ExploitAgent(BaseAgent):
             exploit_agent_message.set_message(
                 f"{combined_log}\nNo exploit script found."
             )
-
-        if git_has_changes(self.tmp_exploits_dir):
-            self._log(f"Found exploit script at: {exploit_script}")
-            git_commit_changes(self.tmp_exploits_dir)
-            await self.execute(exploit_agent_message, prev_agent_message)
-            git_clean_untracked(self.tmp_exploits_dir)
-            self.log_history.clear()
         else:
-            combined_log = self._log(
-                "No changes to exploit_files detected.", clear=True
-            )
-            exploit_agent_message.set_message(f"{combined_log}\nSkipping.")
+            self._log(f"Found exploit script at: {exploit_script}")
+            if git_has_changes(self.tmp_exploits_dir):
+                git_commit_changes(self.tmp_exploits_dir)
+                await self.execute(exploit_agent_message, prev_agent_message)
+                git_clean_untracked(self.tmp_exploits_dir)
+                self.log_history.clear()
+            else:
+                combined_log = self._log(
+                    "No changes to exploit_files detected.", clear=True
+                )
+                exploit_agent_message.set_message(f"{combined_log}\nSkipping.")
 
         return exploit_agent_message
 


### PR DESCRIPTION
### Description
- The exploit agent now only attempts to commit changes if an exploit script is found.
- If the exploit git environment has changes, then the old exploit agent script would assume that the exploit script has changes, and so it would attempt to commit those changes, which would fail since the exploit script is not the file that is modified.
- Here is the error log in the previous version:
```
Found exploit script at: bountybench/setuptools/bounties/bounty_0/tmp_4446077520/exploit.sh
On branch main
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
  (commit or discard the untracked or modified content in submodules)
	modified:   codebase (untracked content)

no changes added to commit (use "git add" and/or "git commit -a")
2025-03-13 10:24:48 WARNING  [utils/git_utils.py:31]
Git command failed: git commit -m Update files at 2025-03-13 10:24:48 - None
2025-03-13 10:24:48 ERROR    [utils/git_utils.py:164]
Failed to commit changes: Command '['git', 'commit', '-m', 'Update files at 2025-03-13 10:24:48']' returned non-zero exit status 1.
Workflow error: Command '['git', 'commit', '-m', 'Update files at 2025-03-13 10:24:48']' returned non-zero exit status 1.
```

### Checklist (Review before submitting)
- [ ] **Unit Tests:**
  - Include test cases for new code or functionality.
  - Ensure all tests pass by running the test suite.
- [ ] **Documentation:**
  - Add or update inline comments where applicable.
  - Update any relevant README or documentation files.
- [ ] **Peer Review:**
  - The PR must be reviewed by at least one team member before merging.
