### PR TITLE
remove failing log lines after running pytests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,3 +136,16 @@ def pytest_ignore_collect(path, config):
     """Ignore certain directories during test collection"""
     ignored_dirs = {".git", ".github", "wip_tests"}
     return any(ignored in str(path) for ignored in ignored_dirs)
+
+
+# ------------------------------------------------------------------------------
+# Logging cleanup
+# ------------------------------------------------------------------------------
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_logging():
+    """Ensure logger queue is properly shutdown after tests complete."""
+    yield
+    # Shutdown the logger queue listener to prevent "I/O operation on closed file" errors
+    from utils.logger import logger_config
+
+    logger_config.shutdown()


### PR DESCRIPTION
when running pytest there are a ton of extra log lines from logging failures - they should be removed