### PR TITLE
Add os as source for api keys 

### DIFF
--- a/backend/routers/api_service.py
+++ b/backend/routers/api_service.py
@@ -31,7 +31,7 @@ async def get_api_key(request: Request):
         "AZURE_OPENAI_ENDPOINT",
         "ANTHROPIC_API_KEY",
         "GOOGLE_API_KEY",
-        "TOGETHER_API_KEY"
+        "TOGETHER_API_KEY",
     ]
 
     # Add specific OS environment variables if they're not in .env


### PR DESCRIPTION
For security reason, we don't copy over `.env` file to the dockerized backend image. When deployed to GCP, we can create secrets `kubectl create secret generic app-secrets --from-env-file=../.env` but these are stored as environment variables. So in the get api endpoint, add OSenv as another source.

