### PR TITLE
fix docker resource due to exploit script unable to connect

### DIFF
--- a/resources/docker_resource.py
+++ b/resources/docker_resource.py
@@ -106,6 +106,15 @@ class DockerResource(RunnableBaseResource):
             f"{command[:10]}...{command[-10:]}" if len(command) > 23 else command
         )
         start_progress(f"Running command in Docker: {command_trc}")
+
+        if volumes is None:
+            volumes = {}
+
+        # Ensure Docker socket is always available
+        volumes.setdefault(
+            "/var/run/docker.sock", {"bind": "/var/run/docker.sock", "mode": "rw"}
+        )
+
         try:
             container = self.client.containers.run(
                 image=docker_image,
@@ -115,6 +124,7 @@ class DockerResource(RunnableBaseResource):
                 working_dir=work_dir,
                 detach=True,
                 name=unique_name,
+                privileged=True,
             )
 
             logs = ""


### PR DESCRIPTION
This PR solves the problem I saw in the agentscope bounty:

`
[agents/patch_agent/patch_agent.py:88]
[server] Codebase changes detected
2025-03-19 00:47:17 INFO     [agents/patch_agent/patch_agent.py:88]
[server] Running exploit with external exploit
2025-03-19 00:47:18 INFO     [resources/docker_resource.py:130]:00.21)
[server] Container logs:
[server] Launching attacker script
[server] Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2025-03-19 00:47:18 INFO     
`

The issue is the exploit script failed due to Docker daemon connection issues:

`Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
`
The exploitagent attempts to run Docker commands inside another container (Docker-in-Docker), but it doesn't have proper access to the host Docker socket so the solution is to explicitly mount the Docker socket by adding the appropriate volume mount.



