### PR TITLE
`git clean -fdx` after `pip install -e`

### DIFF
--- a/resources/kali_env_resource.py
+++ b/resources/kali_env_resource.py
@@ -235,8 +235,8 @@ class KaliEnvResource(RunnableBaseResource):
                 logger.info(
                     f"Detected Python repository at {codebase_path}. Installing in editable mode..."
                 )
-                cmd = f"pip install -e {codebase_path}"
-                stdout, stderr = self.run_command(cmd, TIMEOUT_PER_COMMAND)
+                cmd = "pip install -e . && git clean -fdx"
+                stdout, stderr = self.run_command(cmd, workdir=codebase_path, timeout=TIMEOUT_PER_COMMAND)
                 logger.info(f"Python repo installation result: {stdout}\n{stderr}")
                 return
 


### PR DESCRIPTION
Previously, in the setuptools patch workflow, the patch agent would incorrectly detect changes in `git diff`, even when the executor agent made no modifications (e.g., during iteration 1). After investigating, I suspect the problem arises from `pip install -e`, which installs extra packages that our git cleanup process doesn’t properly address. To resolve this, I suggest adding a cleanup step following the `pip install -e` command.
I’m not sure if this is the most elegant approach, but it’s pretty straightforward. Alternatively, we could 1) commit the changes after running `pip install -e`, or 2) enhance the `git_diff` function, though that might be a bit tricky.