### PR TITLE
Remove gitignore for tmp codebase

### DIFF
--- a/resources/init_files_resource.py
+++ b/resources/init_files_resource.py
@@ -144,7 +144,7 @@ class InitFilesResource(BaseResource):
         # Set up git repos
 
         git_setup_dev_branch(self.files_dir, self.vulnerable_commit)
-        git_init_repo(tmp_destination_path, add_to_gitignore=True)
+        git_init_repo(tmp_destination_path)
 
     def stop(self) -> None:
         """

--- a/utils/git_utils.py
+++ b/utils/git_utils.py
@@ -140,7 +140,6 @@ def git_clean_untracked(directory_path: PathLike) -> None:
 def git_init_repo(
     directory_path: PathLike,
     ignore_dirs: list[str] = None,
-    add_to_gitignore: bool = False,
 ) -> None:
     """Initialize git repository if it doesn't exist."""
     directory = Path(directory_path)
@@ -160,23 +159,6 @@ def git_init_repo(
         gitignore = directory / ".gitignore"
         if not gitignore.exists():
             gitignore.write_text("*.log\n.DS_Store\n")
-
-        # Add additional patterns if requested
-        if add_to_gitignore:
-            additional_patterns = [
-                "*.pyc",
-                "*__pycache__",
-                "*.egg",
-                "*.egg-info",
-                "venv",
-                ".venvs",
-            ]
-            current_content = gitignore.read_text() if gitignore.exists() else ""
-
-            with gitignore.open("a") as f:
-                for pattern in additional_patterns:
-                    if pattern not in current_content:
-                        f.write(f"{pattern}\n")
 
         # If ignore_dirs list is provided, append each entry to .gitignore if not already present
         if ignore_dirs:


### PR DESCRIPTION
This PR reverts fix #606 which added `.pyc` and `__pycache__` to the agent's `.gitignore` file. While that fix correctly removed explicit file deletions (which often failed) (opting to ignore these given files rather than delete), it misidentified the core issue.

The root problem is that patch applications sometimes fail, and our system wasn't properly handling these failures. Auto-generated files (`.pyc`, `node_modules`, etc.) were causing two observed specific errors: ".diff file too large to apply" due to extensive compiled files, and "patch line X corrupted" from binary encoding conflicts.

The correct solution is to implement commit reversion logic on failure (which we were previously lacking and are fixing now). This automatically resets the agent environment when errors occur, removing all problematic auto-generated files without requiring manual intervention. This systematic approach addresses all failure cases rather than targeting specific file types, giving the agent proper opportunity to recover and continue.