### PR TITLE
Refactor patch agent: agent vs external exploit

### DIFF
--- a/agents/patch_agent/patch_agent.py
+++ b/agents/patch_agent/patch_agent.py
@@ -817,6 +817,16 @@ class PatchAgent(BaseAgent):
                 self.bounty_dir / "empty_bounty_scores.json",
             )
 
+    def _load_json_file(self, file_path: Path) -> dict:
+        """Load a JSON file or return an empty dict if it doesn't exist."""
+        if file_path.exists():
+            try:
+                with open(file_path) as f:
+                    return json.load(f)
+            except json.JSONDecodeError:
+                logger.error(f"Error parsing JSON from {file_path}")
+        return {}
+
     def _cleanup_files(self, file_paths: List[Path]) -> None:
         """Delete files if they exist."""
         for path in file_paths:

--- a/tests/agents/test_patch_agent.py
+++ b/tests/agents/test_patch_agent.py
@@ -213,9 +213,7 @@ async def test_agent_exploit_0_then_0_fail(patch_agent, mocker):
         patch_agent, "run_agent_exploit", side_effect=[0, 0]
     )
     # Let invariants pass
-    mocker.patch.object(
-        patch_agent, "run_patch_invariants", return_value=(True, {}, {})
-    )
+    mocker.patch.object(patch_agent, "check_invariants", return_value=True)
 
     initial_msg = PatchAgentMessage(agent_id="test", message="test message")
     final_msg = await patch_agent.run([initial_msg])
@@ -241,7 +239,7 @@ async def test_agent_exploit_1_before_patch(patch_agent, mocker):
         patch_agent, "run_agent_exploit", return_value=1  # unpatched run
     )
     # Invariants won't matter because we won't even get to patch
-    mock_invariants = mocker.patch.object(patch_agent, "run_patch_invariants")
+    mock_invariants = mocker.patch.object(patch_agent, "check_invariants")
 
     initial_msg = PatchAgentMessage(agent_id="test", message="test message")
     final_msg = await patch_agent.run([initial_msg])
@@ -293,9 +291,7 @@ async def test_external_exploit_1_success(patch_agent, mocker):
     mocker.patch("subprocess.run", side_effect=mock_subprocess_run)
 
     # Let invariants pass
-    mocker.patch.object(
-        patch_agent, "run_patch_invariants", return_value=(True, {}, {})
-    )
+    mocker.patch.object(patch_agent, "check_invariants", return_value=True)
 
     # Run
     initial_msg = PatchAgentMessage(
@@ -325,7 +321,7 @@ def test_create_patch_file(bounty_setup, patch_agent, git_fixture):
     assert patch_file_path.exists()
 
 
-def test_run_patch_invariants_success(bounty_setup, patch_agent):
+def test_execute_invariant_tests_success(bounty_setup, patch_agent):
     """Test that run_patch_invariants returns True when invariant checks succeed."""
     agent = patch_agent
     env_path = bounty_setup
@@ -337,21 +333,41 @@ def test_run_patch_invariants_success(bounty_setup, patch_agent):
     write_to_file_and_make_executable(repo_invariants_script, exit_code=0)
     write_to_file_and_make_executable(bounty_invariants_script, exit_code=0)
 
-    # Mock check_invariant_scores_against_thresholds to return True
-    with patch.object(
-        PatchAgent, "check_invariant_scores_against_thresholds", return_value=True
+    # Mock the file reading logic
+    def mock_load_json(path):
+        return {}
+
+    with (
+        patch.object(
+            PatchAgent, "check_invariant_scores_against_thresholds", return_value=True
+        ),
+        patch.object(patch_agent, "_load_json_file", side_effect=mock_load_json),
     ):
-        result, _, _ = agent.run_patch_invariants()
+        # Just verify that files are returned
+        repo_path, bounty_path = agent._execute_invariant_tests()
+        assert isinstance(repo_path, Path)
+        assert isinstance(bounty_path, Path)
 
-    assert result is True
+    # And test check_invariants directly
+    with (
+        patch.object(
+            patch_agent,
+            "_execute_invariant_tests",
+            return_value=(Path("mock1"), Path("mock2")),
+        ),
+        patch.object(
+            PatchAgent, "check_invariant_scores_against_thresholds", return_value=True
+        ),
+        patch.object(
+            patch_agent, "_load_json_file", return_value={"invariant_scores": {}}
+        ),
+        patch.object(patch_agent, "_cleanup_files"),
+    ):
+        result = agent.check_invariants()
+        assert result is True
 
-    # Clean up
-    for script in [repo_invariants_script, bounty_invariants_script]:
-        if script.exists():
-            script.unlink()
 
-
-def test_run_patch_invariants_check_fails(bounty_setup, patch_agent):
+def test_execute_patch_invariants_check_fails(bounty_setup, patch_agent):
     """Test that run_patch_invariants returns False when check_invariant_scores_against_thresholds fails."""
     agent = patch_agent
     env_path = bounty_setup
@@ -362,17 +378,22 @@ def test_run_patch_invariants_check_fails(bounty_setup, patch_agent):
     write_to_file_and_make_executable(repo_invariants_script, exit_code=0)
     write_to_file_and_make_executable(bounty_invariants_script, exit_code=0)
 
-    # Mock check_invariant_scores_against_thresholds to return False
-    with patch.object(
-        PatchAgent, "check_invariant_scores_against_thresholds", return_value=False
+    with (
+        patch.object(
+            PatchAgent, "check_invariant_scores_against_thresholds", return_value=False
+        ),
+        patch.object(
+            patch_agent, "_load_json_file", return_value={"invariant_scores": {}}
+        ),
+        patch.object(
+            patch_agent,
+            "_execute_invariant_tests",
+            return_value=(Path("mock1"), Path("mock2")),
+        ),
+        patch.object(patch_agent, "_cleanup_files"),
     ):
-        result, _, _ = agent.run_patch_invariants()
-
-    assert result is False
-
-    for script in [repo_invariants_script, bounty_invariants_script]:
-        if script.exists():
-            script.unlink()
+        result = agent.check_invariants()
+        assert result is False
 
 
 @pytest.mark.asyncio
@@ -384,7 +405,7 @@ async def test_patch_success_requires_invariants(patch_agent):
     )
 
     # Mock the run_patch_invariants method
-    with patch.object(PatchAgent, "verify_patch_invariants", return_value=False):
+    with patch.object(PatchAgent, "check_invariants", return_value=False):
         # Mock resource restart
         with patch.object(PatchAgent, "_restart_resource", return_value=True):
             # Mock run_agent_exploit to return success
@@ -433,70 +454,58 @@ def test_check_invariant_scores_against_thresholds_success(patch_agent):
                 file.unlink()
 
 
-def test_run_patch_invariants_success_returns_scores(patch_agent):
-    """Test that run_patch_invariants returns True when scores meet thresholds, and returns the scores."""
-    with (
-        tempfile.TemporaryDirectory() as tmpdir
-    ):  # this is a context manager so we don't have to clean up
+def test_check_invariants_returns_correct_scores(patch_agent):
+    """Test that check_invariants properly processes and returns scores."""
+    with tempfile.TemporaryDirectory() as tmpdir:
         task_dir = Path(tmpdir) / "task"
         bounty_dir = Path(tmpdir) / "bounty"
         task_dir.mkdir()
         bounty_dir.mkdir()
 
-        (task_dir / "metadata.json").write_text(json.dumps(MOCK_REPO_METADATA))
-        (task_dir / "invariant_scores.json").write_text(json.dumps(MOCK_REPO_SCORES))
-        (bounty_dir / "bounty_metadata.json").write_text(
-            json.dumps(MOCK_BOUNTY_METADATA)
-        )
-        (bounty_dir / "invariant_scores.json").write_text(
-            json.dumps(MOCK_BOUNTY_SCORES)
-        )
+        # We'll need to create these files in the test setup
+        repo_scores_path = task_dir / "invariant_scores.json"
+        bounty_scores_path = bounty_dir / "invariant_scores.json"
+
+        # Create all necessary files
+        repo_scores_path.write_text(json.dumps(MOCK_REPO_SCORES))
+        bounty_scores_path.write_text(json.dumps(MOCK_BOUNTY_SCORES))
 
         agent = patch_agent
         agent.task_dir = task_dir
         agent.bounty_dir = bounty_dir
-
-        with patch.object(
-            PatchAgent, "check_invariant_scores_against_thresholds", return_value=True
-        ):
-            result, repo_scores, bounty_scores = agent.run_patch_invariants()
-
-        assert result is True
-        assert repo_scores == MOCK_REPO_SCORES
-        assert bounty_scores == MOCK_BOUNTY_SCORES
-
-
-def test_run_patch_invariants_failure_returns_scores(patch_agent):
-    """Test that run_patch_invariants returns False when scores meet thresholds, and still return the scores."""
-    with (
-        tempfile.TemporaryDirectory() as tmpdir
-    ):  # this is a context manager so we don't have to clean up
-        task_dir = Path(tmpdir) / "task"
-        bounty_dir = Path(tmpdir) / "bounty"
-        task_dir.mkdir()
-        bounty_dir.mkdir()
-
-        (task_dir / "metadata.json").write_text(json.dumps(MOCK_REPO_METADATA))
-        (task_dir / "invariant_scores.json").write_text(json.dumps(MOCK_REPO_SCORES))
-        (bounty_dir / "bounty_metadata.json").write_text(
-            json.dumps(MOCK_BOUNTY_METADATA)
-        )
-        (bounty_dir / "invariant_scores.json").write_text(
-            json.dumps(MOCK_BOUNTY_SCORES)
+        agent.last_patch_agent_message = PatchAgentMessage(
+            agent_id="patch_agent", message=None
         )
 
-        agent = patch_agent
-        agent.task_dir = task_dir
-        agent.bounty_dir = bounty_dir
-
-        with patch.object(
-            PatchAgent, "check_invariant_scores_against_thresholds", return_value=False
+        # Mock _execute_invariant_tests to return our prepared files
+        with (
+            patch.object(
+                agent,
+                "_execute_invariant_tests",
+                return_value=(repo_scores_path, bounty_scores_path),
+            ),
+            patch.object(
+                PatchAgent,
+                "check_invariant_scores_against_thresholds",
+                return_value=True,
+            ),
         ):
-            result, repo_scores, bounty_scores = agent.run_patch_invariants()
+            # Run the method
+            result = agent.check_invariants()
 
-        assert result is False
-        assert repo_scores == MOCK_REPO_SCORES
-        assert bounty_scores == MOCK_BOUNTY_SCORES
+            # Verify result
+            assert result is True
+
+            # Check that scores were properly set on the message
+            repo_scores_set = agent.last_patch_agent_message.repo_invariant_scores
+            bounty_scores_set = agent.last_patch_agent_message.bounty_invariant_scores
+
+            assert repo_scores_set.get("invariant_scores") == MOCK_REPO_SCORES.get(
+                "invariant_scores"
+            )
+            assert bounty_scores_set.get("invariant_scores") == MOCK_BOUNTY_SCORES.get(
+                "invariant_scores"
+            )
 
 
 def test_check_invariant_scores_edge_cases(patch_agent):
@@ -537,6 +546,7 @@ def test_check_invariant_scores_edge_cases(patch_agent):
         files["repo_scores"].write_text(json.dumps({"other_key": "value"}))
         result = agent.check_invariant_scores_against_thresholds(*files.values())
         assert result is False
+
     finally:
         # Clean up
         for file in files.values():


### PR DESCRIPTION
This PR refactors logic around running agent vs external exploit. 
Specific change to note: invariants should only be run once in patch agent, previously ran twice (before agent exploit + before external exploit)
Additional changes were made for readability.