### PR TITLE
Remove --text conversion git diff

### DIFF
--- a/utils/git_utils.py
+++ b/utils/git_utils.py
@@ -270,14 +270,13 @@ def git_diff(directory_path: PathLike) -> str:
         # Stage all changes
         _run_git_command(directory, ["add", "-A"])
 
-        # Get staged diff - using specific encoding parameters to handle non-UTF-8 content
+        # Get staged diff
         diff_result = _run_git_command(
             directory,
             [
                 "diff",
                 "--cached",
-                "--text",
-            ],  # Added --text flag to help with binary files
+            ],
             capture_output=True,
             errors="replace",  # Replace invalid characters instead of failing
         )


### PR DESCRIPTION
This PR removes the `--text` flag used in git diff.

The `--text` flag forces Git to treat all files as text, including binary files like .pyc, executables, and images. 
Without --text, Git's default behavior is much more appropriate for our use case:
- Git automatically detects binary files
- For binary files, it shows only a simple indicator like Binary files a/file.pyc and b/file.pyc differ
- The actual binary content is excluded from the diff, preventing corruption of patch files
The `errors="replace"` should be sufficient to handle the issue encountered in #581 

Investigation was prompted when I ran into the below error of corruption, where the patch file contained the binary content of `.pyc` files:
```
[server] Checking for git diff in directory: bountybench/astropy/bounties/bounty_0/tmp_140416905719568/codebase
2025-03-24 17:29:11 INFO     [agents/patch_agent/patch_agent.py:800]
[server] Patch_1 file created successfully at bountybench/astropy/bounties/bounty_0/agent-patches/patch_1.patch
[server] [main e51ddf7] Commit 1
[server]  2 files changed, 0 insertions(+), 0 deletions(-)
2025-03-24 17:29:11 INFO     [utils/git_utils.py:65]
[server] Commit 1 created successfully
[server] Already on 'dev'
2025-03-24 17:29:11 INFO     [utils/git_utils.py:44]
[server] Checked out to branch 'dev'.
[server] error: corrupt patch at line 11
2025-03-24 17:29:11 WARNING  [utils/git_utils.py:36]
[server] Git command failed: git apply /home/cmenders/bountyagent/bountybench/astropy/bounties/bounty_0/agent-patches/patch_1.patch - Command '['git', 'apply', '/home/cmenders/bountyagent/bountybench/astropy/bounties/bounty_0/agent-patches/patch_1.patch']' returned non-zero exit status 128.
2025-03-24 17:29:11 INFO     [utils/git_utils.py:307]
```