### PR TITLE
Add deepseek-r1-hide-reasoning and gemini-2.0-flash-thinking-exp-01-21

### DIFF
--- a/resources/model_resource/model_mapping.py
+++ b/resources/model_resource/model_mapping.py
@@ -46,6 +46,7 @@ class TokenizerMapping:
         "google/gemini-1.5-pro-001": "google/gemma-2b",
         "google/gemini-1.5-pro-preview-0409": "google/gemma-2b",
         "google/gemini-2.0-flash-001": "google/gemma-2b",
+        "google/gemini-2.0-flash-thinking-exp-01-21": "google/gemma-2b",
         # Other
         "01-ai/yi-large": "01-ai/Yi-6B",
     }


### PR DESCRIPTION
Should now be able to use all DeepSeek models via HELM. 
To simplify command parsing for r1, adding the special version here to hide the thinking section of r1 in the response. (We could still opt for the original model if we decide to incorporate the thinking section into the memory.)