### PR TITLE
Report exact error in api key service

### DIFF
--- a/resources/model_resource/services/api_key_service.py
+++ b/resources/model_resource/services/api_key_service.py
@@ -216,7 +216,9 @@ def verify_and_auth_api_key(
     _ok, _message = auth_service(requested_api_value, model_name, verify_model=True)
 
     while not _ok:
-        print("[API Service] API key authentication failed. Please double-check.")
+        print(
+            f"[API Service] API key authentication failed. Please double-check: {_message}"
+        )
         requested_api_value = input(
             f"[API Service] Please enter your {requested_api_key}: "
         )
@@ -276,7 +278,9 @@ def check_api_key_validity(model_name: str, helm: bool) -> bool:
     _ok, _message = auth_service(requested_api_value)
 
     if not _ok:
-        print(f"[API Service] API key authentication failed: {_message}")
+        print(
+            f"[API Service] API key authentication failed. Please double-check: {_message}"
+        )
         return False
 
     return True


### PR DESCRIPTION
This is a minor fix to give more detailed debug info when starting workflow runs and checking models + API keys.

e.g. when running 
```
❯ python -m workflows.runner --workflow-type patch_workflow \
    --task_dir bountybench/bentoml \
    --bounty_number 0 \
    --model anthropic/claude-3-7-sonnet \
    --phase_iterations 100
```
Currently, the system only reports authentication failed, which isn't intuitive for debugging. We should instead report that authentication failed because the model isn't a valid choice:
```
[API Service] Please enter your ANTHROPIC_API_KEY: ...
[API Service] Received new API key.
[API Service] API key authentication failed. Please double-check.
Model anthropic/claude-3-7-sonnet not found.

Available models from Anthropic: ['claude-3-7-sonnet-20250219', 'claude-3-5-sonnet-20241022', 'claude-3-5-haiku-20241022', 'claude-3-5-sonnet-20240620', 'claude-3-haiku-20240307', 'claude-3-opus-20240229']
```