### PR TITLE
Remove stop sequence param when calling LLMs

### DIFF
--- a/resources/model_resource/model_resource.py
+++ b/resources/model_resource/model_resource.py
@@ -1,8 +1,8 @@
+import re
 from dataclasses import dataclass, field
 from typing import Any, List
 
 import tiktoken
-import re
 
 from messages.action_messages.action_message import ActionMessage
 from messages.message import Message


### PR DESCRIPTION
Reasoning models, such as DeepSeek R1 and Gemini 2.0 Thinking, were sometimes producing empty responses during workflow runs. After some investigation, I believed the root cause was the stop token we were sending to the LLMs as the parameter. When the model included the stop token in its reasoning, it stopped generating output early and thus would not generate a final output. 

This PR fixes this by removing the stop token and improves how we handle the model's responses to guarantee they're valid. (Also added a function to remove the thinking part for R1 model)