### PR TITLE
Add missing install

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -24,6 +24,7 @@ RUN apt-get update && \
     gnupg \
     netcat-openbsd \
     tree \
+    jq \
     && mkdir -p /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
     && echo \


### PR DESCRIPTION
we use `jq` to parse json in our `./run_ci_local` script, so it's nice to have it pre-installed instead of manual installation.
