### PR TITLE
Phase message: add invariants output

### DIFF
--- a/agents/patch_agent/patch_agent.py
+++ b/agents/patch_agent/patch_agent.py
@@ -405,7 +405,7 @@ class PatchAgent(BaseAgent):
             exploit_command = "bash exploit.sh"
 
             exploit_execution = DockerActionMessage(
-                resource_id=self.resources.docker.resource_id,
+                resource_id=f"exploit_{self.resources.docker.resource_id}",
                 docker_image="cybench/bountyagent:latest",
                 command=exploit_command,
                 network="shared_net",
@@ -444,7 +444,7 @@ class PatchAgent(BaseAgent):
             exploit_command = "bash exploit.sh true"
 
             exploit_execution = DockerActionMessage(
-                resource_id=self.resources.docker.resource_id,
+                resource_id=f"exploit_{self.resources.docker.resource_id}",
                 docker_image="cybench/bountyagent:latest",
                 command=exploit_command,
                 network="shared_net",
@@ -466,7 +466,7 @@ class PatchAgent(BaseAgent):
                     text=True,
                 )
                 verify_response = ScriptActionMessage(
-                    resource_id=f"subprocess",
+                    resource_id=f"verify_subprocess",
                     message=result.stdout,
                     command=f"./verify.sh {exploit_execution.message}",
                     exit_code=result.returncode,
@@ -786,7 +786,7 @@ class PatchAgent(BaseAgent):
             )
 
             repo_invariants_response = ScriptActionMessage(
-                resource_id=f"subprocess",
+                resource_id=f"repo_invariants_subprocess",
                 message=self._truncate_script_output(
                     repo_result.stdout, repo_result.stderr
                 ),
@@ -810,7 +810,7 @@ class PatchAgent(BaseAgent):
             )
 
             bounty_invariants_response = ScriptActionMessage(
-                resource_id=f"subprocess",
+                resource_id=f"bounty_invariants_subprocess",
                 message=self._truncate_script_output(
                     bounty_result.stdout, bounty_result.stderr
                 ),

--- a/messages/message_handler.py
+++ b/messages/message_handler.py
@@ -47,6 +47,12 @@ class MessageHandler:
 
         # Run the resource again
         resource = self.resource_manager.get_resource(old_message.resource_id)
+        if not resource:
+            logger.error(
+                f"Cannot run {old_message.resource_id}, no corresponding resource found in resource dict"
+            )
+            return
+
         new_action: ActionMessage = resource.run(input_message)
 
         # Keep next link if the old action had one


### PR DESCRIPTION
This PR adds invariants output as an action message in PhaseMessage, automatically truncates output to 5000 chars. 
Also adds more descriptive naming for action messages + in message handler ensures interactive action buttons will skip these 'artificial' resources.