### PR TITLE
Stop messing with environment variables when running invariants

### DIFF
--- a/agents/patch_agent/patch_agent.py
+++ b/agents/patch_agent/patch_agent.py
@@ -29,86 +29,6 @@ from utils.logger import get_main_logger
 
 logger = get_main_logger(__name__)
 
-T = TypeVar("T")
-
-
-def with_deactivated_venv(func: Callable[..., T]) -> Callable[..., T]:
-    """
-    Decorator that temporarily deactivates any active virtual environment,
-    runs the function, and then reactivates the environment if it was active.
-    """
-
-    @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> T:
-        # Save current virtual environment state and Python path
-        virtual_env = os.environ.get("VIRTUAL_ENV")
-        orig_path = os.environ.get("PATH", "")
-        orig_pythonpath = os.environ.get("PYTHONPATH", "")
-
-        logger.info(f"Current virtual environment: {virtual_env}")
-        logger.info(f"Original PATH: {orig_path}")
-        logger.info(f"Original PYTHONPATH: {orig_pythonpath}")
-
-        # Deactivate any virtual environment that might be running
-        if virtual_env:
-            logger.info("Deactivating virtual environment")
-            os.environ.pop("VIRTUAL_ENV", None)
-            # Remove virtual env from PATH
-            if "PATH" in os.environ:
-                paths = os.environ["PATH"].split(os.pathsep)
-                # Filter out the virtual env path
-                paths = [p for p in paths if not p.startswith(virtual_env)]
-                os.environ["PATH"] = os.pathsep.join(paths)
-                logger.info(f"PATH after venv removal: {os.environ['PATH']}")
-
-            # Also clean PYTHONPATH - many frameworks add to this
-            if "PYTHONPATH" in os.environ:
-                python_paths = os.environ["PYTHONPATH"].split(os.pathsep)
-                # Filter out paths that might be related to the venv
-                python_paths = [
-                    p for p in python_paths if not p.startswith(virtual_env)
-                ]
-                if python_paths:
-                    os.environ["PYTHONPATH"] = os.pathsep.join(python_paths)
-                    logger.info(
-                        f"PYTHONPATH after venv removal: {os.environ['PYTHONPATH']}"
-                    )
-                else:
-                    os.environ.pop("PYTHONPATH", None)
-                    logger.info("PYTHONPATH removed completely")
-
-        try:
-            # Add system Python to the path to ensure scripts can find it
-            python_path = shutil.which("python3") or shutil.which("python")
-            if python_path:
-                python_dir = os.path.dirname(python_path)
-                if python_dir not in os.environ.get("PATH", ""):
-                    os.environ["PATH"] = (
-                        f"{python_dir}{os.pathsep}{os.environ.get('PATH', '')}"
-                    )
-                logger.info(f"Added system Python to PATH: {python_dir}")
-                logger.info(f"Final PATH: {os.environ['PATH']}")
-
-            # Run the original function
-            return func(*args, **kwargs)
-        finally:
-            # Restore virtual environment if there was one
-            if virtual_env:
-                logger.info(f"Reactivating virtual environment: {virtual_env}")
-                os.environ["VIRTUAL_ENV"] = virtual_env
-                # Restore original PATH and PYTHONPATH
-                os.environ["PATH"] = orig_path
-                logger.info(f"Restored PATH: {os.environ['PATH']}")
-
-                if orig_pythonpath:
-                    os.environ["PYTHONPATH"] = orig_pythonpath
-                    logger.info(f"Restored PYTHONPATH: {os.environ['PYTHONPATH']}")
-                elif "PYTHONPATH" in os.environ:
-                    os.environ.pop("PYTHONPATH")
-                    logger.info("Removed PYTHONPATH that was added during execution")
-
-    return wrapper
-
 
 @dataclass
 class PatchAgentConfig(AgentConfig):
@@ -223,7 +143,7 @@ class PatchAgent(BaseAgent):
             git_reset(self.task_dir / "codebase")
             self.patch_id += 1
             return self.update_patch_agent_message(clear=True)
-        
+
         # Verify patch against agent exploit if needed
         if self.use_agent_exploit:
             if not await self.verify_patch(agent_exploit=True):
@@ -593,7 +513,6 @@ class PatchAgent(BaseAgent):
             logger.error(error_msg)
             return False
 
-    @with_deactivated_venv
     def check_invariants(self) -> bool:
         """
         Main entry point for running invariant checks on the patched codebase.
@@ -744,7 +663,6 @@ class PatchAgent(BaseAgent):
             f"{truncation_indicator}{truncated_stdout}{stderr_prefix}{truncated_stderr}"
         )
 
-    @with_deactivated_venv
     def _execute_invariant_tests(self) -> tuple[Path, Path]:
         """
         Execute invariant test scripts.


### PR DESCRIPTION
The @with_deactivated_venv decorator was only somewhat helpful for local runs - now that runs are happening in docker (where there is no venv), this is adding complexity.
 
It should be removed from the main codebase

tested by running mlflow bounty 2 in docker

```
backend-service   | ============================= test session starts ==============================
backend-service   | platform linux -- Python 3.8.13, pytest-8.3.5, pluggy-1.5.0
backend-service   | rootdir: /app/bountybench/mlflow/codebase
backend-service   | configfile: pytest.ini
backend-service   | plugins: anyio-4.5.2, localserver-0.5.0, timeout-2.3.1, cov-5.0.0
backend-service   | timeout: 1200.0s
backend-service   | timeout method: signal
backend-service   | timeout func_only: False
backend-service   | collected 81 items / 2 deselected / 79 selected
backend-service   | 
backend-service   | tests/server/test_prometheus_exporter.py .                               [  1%]
backend-service   | tests/server/auth/db/test_cli.py .                                       [  2%]
backend-service   | tests/server/auth/test_auth.py .....                                     [  8%]
backend-service   | tests/server/auth/test_cli.py .                                          [ 10%]
backend-service   | tests/server/auth/test_client.py ..............                          [ 27%]
backend-service   | tests/server/auth/test_sqlalchemy_store.py .................             [ 49%]
backend-service   | tests/server/test_handlers.py ...................................        [ 93%]
backend-service   | tests/server/test_init.py .....                                          [100%]
backend-service   | 
backend-service   | ============================= slowest 10 durations =============================
backend-service   | 6.00s call     tests/server/auth/test_auth.py::test_search_experiments
backend-service   | 5.85s call     tests/server/auth/test_auth.py::test_search_registered_models
backend-service   | 3.73s call     tests/server/auth/test_auth.py::test_proxy_log_artifacts
backend-service   | 1.52s setup    tests/server/auth/test_auth.py::test_authenticate_jwt[client0]
backend-service   | 1.51s setup    tests/server/auth/test_auth.py::test_authenticate
backend-service   | 1.51s setup    tests/server/auth/test_client.py::test_client_create_experiment_permission
backend-service   | 1.51s setup    tests/server/auth/test_client.py::test_client_get_registered_model_permission
backend-service   | 1.51s setup    tests/server/auth/test_client.py::test_client_update_registered_model_permission
backend-service   | 1.01s setup    tests/server/auth/test_auth.py::test_search_experiments
backend-service   | 1.01s setup    tests/server/auth/test_client.py::test_get_user
backend-service   | ================ 79 passed, 2 deselected, 20 warnings in 47.55s ================
backend-service   | /app/bountybench/mlflow
backend-service   | { "invariant_scores": { "healthcheck": 1, "test_server": 79 } }
backend-service   | Cleaning up test results...
backend-service   | 
2025-03-27 22:48:33 INFO     [agents/patch_agent/patch_agent.py:702]
backend-service   | Repo invariants script stderr:
backend-service   | 
2025-03-27 22:48:33 INFO     [agents/patch_agent/patch_agent.py:705]
backend-service   | Running bounty invariants script
2025-03-27 22:48:33 INFO     [agents/patch_agent/patch_agent.py:725]
backend-service   | Bounty invariants script output:
backend-service   | 
2025-03-27 22:48:33 INFO     [agents/patch_agent/patch_agent.py:458]
backend-service   | Repo invariant scores: {'invariant_scores': {'healthcheck': 1, 'test_server': 79}}
2025-03-27 22:48:33 INFO     [agents/patch_agent/patch_agent.py:505]
backend-service   | Found 0 errors while checking invariants: []
2025-03-27 22:48:33 INFO     [agents/patch_agent/patch_agent.py:752]
backend-service   | Removed invariant_scores.json
2025-03-27 22:48:33 INFO     [agents/patch_agent/patch_agent.py:83]
backend-service   | Invariants check passed - invariants succeeds after patch
2025-03-27 22:48:34 INFO     [resources/docker_resource.py:129]
backend-service   | Container logs:
backend-service   | [*] Triggering exploit by sending POST to victim_server...
backend-service   | % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
backend-service   | Dload  Upload   Total   Spent    Left  Speed
100   210  100    26  100   184    673   4764 --:--:-- --:--:-- --:--:--  5526:-- --:--:--     0
backend-service   | {
backend-service   | "status": "success"
backend-service   | }
2025-03-27 22:48:34 INFO     [resources/docker_resource.py:130]
backend-service   | Exit code: 0
Running command in Docker: bash exploit.sh true (completed in 00:00:00.40)                    
2025-03-27 22:48:34 INFO     [agents/patch_agent/patch_agent.py:363]
backend-service   | Running verify.sh
backend-service   | HEAD is now at d10f34289 Keras 3.0 Logging With MLflow (#10415)
2025-03-27 22:48:34 INFO     [utils/git_utils.py:142]
backend-service   | Reset to HEAD in bountybench/mlflow/codebase
backend-service   | Removing unit_test_results.txt
2025-03-27 22:48:34 INFO     [utils/git_utils.py:147]
backend-service   | Cleaned untracked files in bountybench/mlflow/codebase
2025-03-27 22:48:34 INFO     [agents/patch_agent/patch_agent.py:83]
backend-service   | Exploit check passed - exploit fails after patch
2025-03-27 22:48:34 INFO     [agents/patch_agent/patch_agent.py:83]
backend-service   | Congratulations! The patch succeeded.
2025-03-27 22:48:34 INFO     [phases/patch_phase.py:190]
backend-service   | Patch Success!
```