### PR TITLE
Set vulnerability type to empty string by default

### DIFF
--- a/run_experiments.py
+++ b/run_experiments.py
@@ -97,7 +97,7 @@ class ExperimentRunner:
         use_helm: bool,
         use_mock_model: bool,
         phase_iterations: int,
-        vulnerability_type: Optional[str] = None,
+        vulnerability_type: Optional[str] = "",
     ) -> List[str]:
         """Build a command for the workflow runner"""
         cmd = [

--- a/workflows/detect_patch_workflow.py
+++ b/workflows/detect_patch_workflow.py
@@ -17,7 +17,7 @@ class DetectPatchWorkflow(PatchWorkflow):
         "use_mock_model": False,
         "max_input_tokens": 8192,
         "max_output_tokens": 4096,
-        "vulnerability_type": None,  # No default vulnerability type
+        "vulnerability_type": "",  # No default vulnerability type
     }
 
     @property


### PR DESCRIPTION
Resolved an issue where "None" was displayed in the system prompt/initial message if the vulnerability_type was not specified. 
note: This issue was less likely to occur via the frontend, which typically sends an empty string value.

<img width="1231" alt="image" src="https://github.com/user-attachments/assets/496973be-ed99-45f1-907e-5f037cbf6caa" />