### PR TITLE
KaliEnvResource: use 10, 20 minute timeouts

### DIFF
--- a/resources/kali_env_resource.py
+++ b/resources/kali_env_resource.py
@@ -27,12 +27,12 @@ DOCKER_IMAGE: str = "cybench/bountyagent:latest"
 ENTRYPOINT: str = "/usr/local/bin/dockerd-entrypoint.sh"
 DOCKER_CLIENT_INIT_TIMEOUT: int = 300
 
-TIMEOUT_PER_COMMAND: int = 3600
+TIMEOUT_PER_COMMAND: int = 600
 MAX_RETRIES: int = 3
 RETRY_DELAY: int = 5
 
-# Use a 10-minute timeout for pip installation
-PIP_INSTALL_TIMEOUT: int = 600
+# Use a 20-minute timeout for pip installation
+PIP_INSTALL_TIMEOUT: int = 1200
 
 # Configure logging
 logger = get_main_logger(__name__)
@@ -239,8 +239,14 @@ class KaliEnvResource(RunnableBaseResource):
                 f"Detected Python repository at {codebase_path}. Installing in editable mode..."
             )
             # Use the custom install command if provided, otherwise default to editable install
-            cmd = self.install_command if self.install_command is not None else "pip install -e ."
-            stdout, stderr = self.run_command(command=cmd, timeout=PIP_INSTALL_TIMEOUT, workdir=codebase_path)
+            cmd = (
+                self.install_command
+                if self.install_command is not None
+                else "pip install -e ."
+            )
+            stdout, stderr = self.run_command(
+                command=cmd, timeout=PIP_INSTALL_TIMEOUT, workdir=codebase_path
+            )
             logger.info(f"Python repo installation result: {stdout}\n{stderr}")
 
             host_path = self._map_container_path_to_host(codebase_path)

--- a/tests/resources/test_kali_env_resource.py
+++ b/tests/resources/test_kali_env_resource.py
@@ -236,9 +236,11 @@ def test_install_python_repo(
     mock_run_command.assert_has_calls(
         [
             mock.call(
-                "[ -d /app/codebase ] && echo 'exists' || echo 'not_exists'", 3600
+                "[ -d /app/codebase ] && echo 'exists' || echo 'not_exists'", 600
             ),
-            mock.call(command='pip install -e .', timeout=600, workdir='/app/codebase'),
+            mock.call(
+                command="pip install -e .", timeout=1200, workdir="/app/codebase"
+            ),
         ],
         any_order=False,
     )
@@ -262,7 +264,7 @@ def test_install_node_repo(
     # Verify run command only called once (to verify codebase exist) - we should skip Node.js installation
 
     mock_run_command.assert_called_once_with(
-        "[ -d /app/codebase ] && echo 'exists' || echo 'not_exists'", 3600
+        "[ -d /app/codebase ] && echo 'exists' || echo 'not_exists'", 600
     )
 
 


### PR DESCRIPTION
Default 10-minute time out for kali `run_command`, 20-minute time out for `pip install -e`