### PR TITLE
Patch Agent: No longer commit tmp codebase after changes

### DIFF
--- a/agents/patch_agent/patch_agent.py
+++ b/agents/patch_agent/patch_agent.py
@@ -410,7 +410,6 @@ class PatchAgent(BaseAgent):
                 patch_file_path = self.create_patch_file(
                     tmp_dir_diff, self.output_patch_subfolder
                 )
-                git_commit(self.codebase, self.patch_id)
             except Exception as e:
                 self._log(f"Failed to create patch file: {str(e)}")
                 return False


### PR DESCRIPTION
We should no longer be committing agent codebase state when a git diff is detected. We changed workflow to just reset dirty changes, but left a `git_commit`, causing agent codebase and remote codebase to be unaligned and patch applications to fail between files due to different states. 

Leaving `git_commit` here was an oversight