### PR TITLE
Websocket: Add escape to infinite loop when web socket not connected

### DIFF
--- a/backend/execution_backends/local_execution_backend.py
+++ b/backend/execution_backends/local_execution_backend.py
@@ -402,7 +402,6 @@ class LocalExecutionBackend(ExecutionBackend):
                         )
                         break
 
-                    await asyncio.sleep(0.5)
 
         except Exception as e:
             print(f"WebSocket error for workflow {workflow_id}: {e}")


### PR DESCRIPTION
Fix WebSocket infinite error loop by catching `not connected` state and properly terminating broken connections, preventing `WebSocket is not connected.` errors from flooding logs when web socket becomes unexpectedly disconnected.
e.g.:
![image](https://github.com/user-attachments/assets/dea04b6e-a501-4663-ab12-85dedd7c3be2)