### PR TITLE
Nginx Proxy: fix ws connection issues 

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,7 +1,7 @@
 server {
     listen 80;
     server_name localhost;
-
+    
     # Base frontend route in order to serve the frontend application in the browser
     location / {
         proxy_pass http://frontend-service:3000;
@@ -10,10 +10,10 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-    # WebSocket connection (/ws and /ws/workflow_id routes)
-    location ~* ^/ws(/.*)?$ {
-        # Allow flexible WebSocket headers
-        proxy_pass http://backend-service:7999/ws$1;
+    # Backend WebSocket connections - require workflow ID
+    location ~ ^/ws/([^/]+)$ {
+        # Backend WebSocket with workflow ID
+        proxy_pass http://backend-service:7999/ws/$1;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -24,8 +24,15 @@ server {
         proxy_read_timeout 86400;  # Prevent socket timeout
     }
 
-    # Detect requests from the frontend application running in the browser
-    # and redirect to the backend
+    # Frontend service uses its own development WebSocket
+    location = /ws {
+        proxy_pass http://frontend-service:3000/ws;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+
     # -- Workflow endpoints
     location /workflow/ {
         proxy_pass http://backend-service:7999/workflow/;


### PR DESCRIPTION
In dockerized environment: 
Frontend was experiencing websocket connection failures with 2 error codes: `301` and `403`.

The `301` error was caused by a trailing Slash Problem: the original Nginx configuration defined the `/ws/` endpoint (with a trailing slash), causing 301 redirects for `/ws`.
`403` errors occurred when the redirected `/ws` connections were sent to the `backend/ws/` route and got `403 forbidden` errors from the backend. 

All WebSocket connections were being sent to the backend, but there are two distinct types:
- React development server WebSockets (`/ws`) (implemented by them)
- our workflow WebSockets `/ws/workflow-id`

This PR adds a `location = /ws` exact match route for React's development server WebSocket (frontend React WebSocket requests get sent back to frontend) and a `location ~ ^/ws/([^/]+)$` (with better pattern matching to require workflow-id) used by our workflows sent to the backend.


![Screenshot 2025-03-28 191444](https://github.com/user-attachments/assets/dc36fc62-f6df-4424-b179-6a7669eecc29)