### PR TITLE
Nginx error handling

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -38,15 +38,6 @@ server {
         proxy_set_header Host $host;
     }
 
-    # Frontend service uses its own development WebSocket
-    location = /ws {
-        proxy_pass http://frontend-service:3000/ws;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_set_header Host $host;
-    }
-
     # -- Workflow endpoints
     location /workflow/ {
         proxy_pass http://backend-service:7999/workflow/;


### PR DESCRIPTION
When the backend service is unavailable or returns errors, the frontend receives HTML error pages instead of properly formatted JSON responses, surfacing the error: `Unexpected token '<', "<html> <h"... is not valid JSON`

This PR adds custom error handling (`proxy_intercept_errors on`) to format errors into representable JSON for frontend

Note that when the backend is busy (e.g. blocked on a task), we will see `503 service temporarily unavailable` error:
![image](https://github.com/user-attachments/assets/f742a1b3-a1e0-4f6e-94bc-49ca79afb549)
