### PR TITLE
Fix: websocket state check

### DIFF
--- a/backend/execution_backends/local_execution_backend.py
+++ b/backend/execution_backends/local_execution_backend.py
@@ -387,7 +387,7 @@ class LocalExecutionBackend(ExecutionBackend):
                         # Heartbeat is handled internally by WebSocketManager
                         continue
                 except asyncio.TimeoutError:
-                    # Timeout is normal, verify client state is not disconnected connected, continue the loop to check conditions again
+                    # Timeout is normal, verify client state is not disconnected, continue the loop to check conditions again
                     if websocket.client_state == WebSocketState.DISCONNECTED:
                         print(f"Client disconnected for workflow {workflow_id}")
                         break


### PR DESCRIPTION
This PR fixes improper attribute error that caused websocket to break after being established, causing frontend to not update. Issue caused in #664 as an additional functionality and error was not caught (by me)
Uses `WebSocketState` check directly instead.