### PR TITLE
Fix npm / node issue in the kali linux container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,12 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Install Node.js and npm
+RUN apt-get update && \
+    apt-get install -y nodejs npm && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
     chmod +x /usr/local/bin/docker-compose
 


### PR DESCRIPTION
Our Kali Linux Docker container currently includes node but is missing npm, which is unusual since they're normally installed together. This absence creates problems for Node.js-specific bounties. This PR updates the Dockerfile to add npm and fix this issue.

I'm also preparing to push a new Kali Linux image to Docker Hub. If you have any other changes you'd like to make to this Dockerfile, please let me know.

<img width="786" alt="image" src="https://github.com/user-attachments/assets/c6e4c85f-c873-41a7-b189-0e9e7e9dfbcf" />
