### PR TITLE
add node modules to git ignore

### DIFF
--- a/utils/git_utils.py
+++ b/utils/git_utils.py
@@ -260,6 +260,8 @@ def git_init_repo(directory_path: PathLike, ignore_dirs: list[str] = None) -> No
         gitignore = directory / ".gitignore"
         if not gitignore.exists():
             gitignore.write_text("*.log\n.DS_Store\n")
+            gitignore.write_text("\n# Node.js dependencies\nnode_modules/\n")
+
 
         # If ignore_dirs list is provided, append each entry to .gitignore if not already present
         if ignore_dirs:


### PR DESCRIPTION
<img width="666" alt="image" src="https://github.com/user-attachments/assets/36cfed76-28a9-4f47-af23-da2a62536724" />

When we run git diff with too many file paths as individual command-line arguments (likely thousands of Node.js module files from the node_modules directory), it exceeds the system's limit for command-line argument length so added it to git ignore since we don't need to add the node modules.