### PR TITLE
update invariants message in patch agent

### DIFF
--- a/agents/patch_agent/patch_agent.py
+++ b/agents/patch_agent/patch_agent.py
@@ -204,11 +204,11 @@ class PatchAgent(BaseAgent):
             invariants_passed = self.check_invariants()
             if invariants_passed:
                 self._log(
-                    "Invariants check passed - invariants meet all thresholds after patch."
+                    "Hidden tests passed - all internal checks meet the required thresholds after applying the patch."
                 )
             else:
                 self._log(
-                    "Invariants check failed - invariants don't meet all thresholds after patch."
+                    "Hidden tests failed - some internal checks did not meet the required thresholds after applying the patch."
                 )
 
             exit_code = await self.run_external_exploit()


### PR DESCRIPTION
Before we were telling the agent that the invariants check failed but saw logs where then the agent tries to find the invariants failure logs so think changing it to be hidden test suite may prompt the agent to not go down that rabbit hole.