### PR TITLE
workflow_data dict key access

### DIFF
--- a/backend/execution_backends/local_execution_backend.py
+++ b/backend/execution_backends/local_execution_backend.py
@@ -175,11 +175,19 @@ class LocalExecutionBackend(ExecutionBackend):
             active_workflows_list.append(
                 {
                     "id": workflow_id,
-                    "status": workflow_data["status"],
-                    "name": workflow_data["instance"].__class__.__name__,
-                    "task": workflow_data["instance"].task,
+                    "status": workflow_data.get("status", "unknown"),
+                    "name": (
+                        workflow_data.get("instance", {}).__class__.__name__
+                        if "instance" in workflow_data
+                        else "Unknown"
+                    ),
+                    "task": (
+                        workflow_data.get("instance").task
+                        if "instance" in workflow_data
+                        else None
+                    ),
                     "timestamp": getattr(
-                        workflow_data["workflow_message"], "timestamp", None
+                        workflow_data.get("workflow_message", {}), "timestamp", None
                     ),
                 }
             )


### PR DESCRIPTION
This PR safely accesses `workflow_data` keys, defaults on `"Unknown"/None` values to avoid `KeyError` issues:

```
[server] INFO:     127.0.0.1:48026 - "OPTIONS /workflow/start HTTP/1.1" 200 OK
[server] INFO:     ('127.0.0.1', 60916) - "WebSocket /ws/139862409564304" [accepted]
[server] INFO:     connection open
[server] WebSocket connecting for workflow 139862409564304
[server] WebSocket connected for workflow 139862409564304
[server] Auto-starting new workflow 139862409564304
[server] Error listing workflows: 'instance'
[server] Traceback (most recent call last):
[server]   File "/home/cmenders/bountyagent/backend/routers/workflows.py", line 43, in list_active_workflows
[server]     workflows = await execution_backend.list_active_workflows()
[server]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[server]   File "/home/cmenders/bountyagent/backend/execution_backends/local_execution_backend.py", line 179, in list_active_workflows
[server]     "name": workflow_data["instance"].__class__.__name__,
[server]             ~~~~~~~~~~~~~^^^^^^^^^^^^
[server] KeyError: 'instance'
[server]
[server] INFO:     127.0.0.1:52412 - "GET /workflow/active HTTP/1.1" 200 OK
[server] Error listing workflows: 'instance'
[server] Traceback (most recent call last):
[server]   File "/home/cmenders/bountyagent/backend/routers/workflows.py", line 43, in list_active_workflows
[server]     workflows = await execution_backend.list_active_workflows()
[server]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[server]   File "/home/cmenders/bountyagent/backend/execution_backends/local_execution_backend.py", line 179, in list_active_workflows
[server]     "name": workflow_data["instance"].__class__.__name__,
[server]             ~~~~~~~~~~~~~^^^^^^^^^^^^
[server] KeyError: 'instance'
[server]
```
