### PR TITLE
Message parsing: find last occurrence of a field

### DIFF
--- a/messages/parse_message.py
+++ b/messages/parse_message.py
@@ -2,7 +2,11 @@ from typing import List, Optional
 
 
 def parse_field(
-    text: str, field: str, multiline: bool = True, stop_str: Optional[str] = None
+    text: str,
+    field: str,
+    multiline: bool = True,
+    stop_str: Optional[str] = None,
+    from_end: Optional[bool] = True,
 ) -> Optional[str]:
     """
     Extracts a field value from the input text based on the given field name.
@@ -12,6 +16,7 @@ def parse_field(
     - field: The name of the field to extract.
     - multiline: If True, extracts multiple lines until an optional stop string or the end of the text.
     - stop_str: An optional string that defines where the field extraction should stop.
+    - from_end: If True, finds the last instance of the field in the text instead of the first.
 
     Returns:
     - The extracted field value as a string if found, or None if not found.
@@ -21,7 +26,12 @@ def parse_field(
 
     # Find the start index for the field
     field_marker = f"{field}"
-    start_index = text.lower().find(field_marker.lower())
+
+    if from_end:
+        start_index = text.lower().rfind(field_marker.lower())
+    else:
+        start_index = text.lower().find(field_marker.lower())
+
     if start_index == -1:
         # Field not found
         return None


### PR DESCRIPTION
This PR changes the `parse_field` function to support finding either the first or last occurrence of a field in a text (defaults to last, assuming a temporal nature of the messages where the newest occurance will appear last). 

In one run, the agent included `Command: {cmd}` in its log list, so we executed the logged (previous) command instead of the new one.

![image](https://github.com/user-attachments/assets/75a6e93f-7aae-4890-9afa-467ebef5908a)
![image](https://github.com/user-attachments/assets/96e69ebc-8aa8-46f4-967f-2dcc130f2037)

When `from_end=True`, the function uses `rfind()` to locate the last occurrence of the field marker in the text, rather than the first occurrence. 

e.g.:
```python
# Get last occurrence (new behavior)
result1 = parse_field(text, "Field:", multiline=True)

# Get first occurrence (original behavior)
result2 = parse_field(text, "Field:", multiline=True, from_end=False)
```
