### PR TITLE
Do not pass exploit output into `verify.sh`

### DIFF
--- a/agents/patch_agent/patch_agent.py
+++ b/agents/patch_agent/patch_agent.py
@@ -221,9 +221,7 @@ class PatchAgent(BaseAgent):
                     )
             else:
                 if exit_code == 1:
-                    self._log(
-                        "External exploit check (optional) passed - exploit fails after patch."
-                    )
+                    self._log("External exploit check (optional) passed - exploit fails after patch.")
                 else:
                     self._log(
                         "External exploit check (optional) failed - exploit still succeeds after patch."
@@ -337,12 +335,8 @@ class PatchAgent(BaseAgent):
                 }
 
                 # Check if it's a Python repo and install if needed, then run exploit
-                install_command = (
-                    self.install_command
-                    if self.install_command
-                    else "pip install --quiet -e ."
-                )
-
+                install_command = self.install_command if self.install_command else "pip install --quiet -e ."
+                
                 # Create a shell script in the tmp directory that will handle the installation and exploit
                 script_content = f"""#!/bin/bash
 # Check if Python project and install if needed
@@ -357,14 +351,14 @@ fi
 # Run the exploit script
 bash /app/exploit.sh
 """
-
+                
                 # Write the script to a file in the tmp directory
                 with open(script_path, "w") as f:
                     f.write(script_content)
-
+                
                 # Make the script executable
                 script_path.chmod(script_path.stat().st_mode | 0o755)
-
+                
                 # Use the script as the command
                 exploit_command = "bash /app/run_exploit.sh"
 


### PR DESCRIPTION
Outdated concept: we pass exploit output into `verify.sh`, may be validating some information, e.g. a `flag`.

Now, for all verification, we will directly check state / files to determine whether an exploit successfully ran. 

This PR removes uncessesarily passing exploit output to the verify script during `PatchAgent` external exploit verification
![image](https://github.com/user-attachments/assets/fe6cb60b-b481-4410-90d0-b4034576a2c7)
