### PR TITLE
`ActionMessage` `additional_metadata`: use non-mutable default argument

### DIFF
--- a/messages/action_messages/action_message.py
+++ b/messages/action_messages/action_message.py
@@ -8,12 +8,12 @@ class ActionMessage(Message):
         self,
         resource_id: str,
         message: str,
-        additional_metadata: Optional[Dict[str, Any]] = {},
+        additional_metadata: Optional[Dict[str, Any]] = None,
         prev: "ActionMessage" = None,
     ) -> None:
         self._resource_id = resource_id
         self._message = message
-        self._additional_metadata = additional_metadata
+        self._additional_metadata = additional_metadata or {}
         self._memory = None
 
         super().__init__(prev)

--- a/messages/action_messages/script_action_message.py
+++ b/messages/action_messages/script_action_message.py
@@ -10,9 +10,11 @@ class ScriptActionMessage(ActionMessage):
         command: str,
         message: Optional[str] = "",
         exit_code: Optional[int] = None,
-        additional_metadata: Optional[Dict[str, Any]] = {},
+        additional_metadata: Optional[Dict[str, Any]] = None,
         prev: Optional[ActionMessage] = None,
     ) -> None:
+
+        additional_metadata = additional_metadata or {}
         additional_metadata["exit_code"] = exit_code
         additional_metadata["command"] = command
 


### PR DESCRIPTION
This PR fixes an issue where multiple `ActionMessage` and `ScriptActionMessage` instances could unintentionally share the same `additional_metadata` dictionary due to the use of a mutable default argument (`{}`).

Using mutable defaults can lead to subtle bugs when modifying the dictionary, as changes in one instance can affect others — especially problematic when chaining messages using the `prev` parameter. I replaced `additional_metadata: Optional[Dict[str, Any]] = {}` with `= None` in constructors to prevent this.

Fixed bug: `PatchAgent` `ScriptActionMessage`s were mutating others `additional_metadata` (seen here with `verify.sh` set as the command for bounty invariants rather than `run_bounty_invariants.sh`)

![image](https://github.com/user-attachments/assets/198c429d-fbc3-4f5c-b9e8-8fa6ca1cce76)