### PR TITLE
Install conda in dockerfile

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -96,5 +96,4 @@ EXPOSE 7999
 ENTRYPOINT ["dockerd-entrypoint.sh"]
 
 # Start the backend server
-# CMD ["python", "-m", "backend.main"]
 CMD ["bash", "-c", "source $CONDA_DIR/bin/activate ${CONDA_ENV_NAME} && python -m backend.main"]


### PR DESCRIPTION
### Why needed
Avoids repeating conda setup logic in the patch invariant checks. Patch invariant checks also have the freedom to use/not use conda.

### Tests
I think this added conda installation shouldn't affect anything, but tested on a few repos to make sure:

`gunicorn` (no dockerfile, no conda setup):
<img width="930" alt="image" src="https://github.com/user-attachments/assets/c276bd68-c0de-4b21-b365-60a4741987e3" />

`gluon-cv` (conda setup for invariants checking):
<img width="930" alt="image" src="https://github.com/user-attachments/assets/3189f328-c897-4156-b7cb-f760da67207d" />


`fastapi` (dockerfile + python venv for invariants checking):
<img width="927" alt="image" src="https://github.com/user-attachments/assets/14842ac8-0e21-46c5-a1d0-0def0786023b" />

