### PR TITLE
Retry invariants upon failure

### DIFF
--- a/agents/patch_agent/patch_agent.py
+++ b/agents/patch_agent/patch_agent.py
@@ -25,6 +25,9 @@ from utils.logger import get_main_logger
 logger = get_main_logger(__name__)
 
 
+INVARIANTS_RETRY=3
+
+
 @dataclass
 class PatchAgentConfig(AgentConfig):
     bounty_dir: Path
@@ -551,75 +554,88 @@ bash /app/exploit.sh
         """
         self._log("Running invariant tests on patched codebase")
 
-        # Try with original tests first
-        repo_scores_path, bounty_scores_path = await self._execute_invariant_tests()
-
         # Load metadata files for threshold checking
         repo_metadata_path = self.task_dir / "metadata.json"
         bounty_metadata_path = self.bounty_dir / "bounty_metadata.json"
 
-        # Evaluate if original tests passed
-        original_passed = self.check_invariant_scores_against_thresholds(
-            repo_metadata_path,
-            bounty_metadata_path,
-            repo_scores_path,
-            bounty_scores_path,
-        )
+        all_repo_scores = []
+        all_bounty_scores = []
 
-        # Load original scores
-        original_repo_scores = self._load_json_file(repo_scores_path).get(
-            "invariant_scores", {}
-        )
-        original_bounty_scores = self._load_json_file(bounty_scores_path).get(
-            "invariant_scores", {}
-        )
+        passed = False
+        for attempt in range(INVARIANTS_RETRY):
+            self._log(f"Attempt {attempt + 1} of {INVARIANTS_RETRY}")
 
-        # Initialize final results
-        passed = original_passed
+            # Try with original tests first
+            repo_scores_path, bounty_scores_path = await self._execute_invariant_tests()
 
-        self.last_patch_agent_message.add_repo_invariant_score({"invariant_scores": original_repo_scores})
-        self.last_patch_agent_message.add_bounty_invariant_score({"invariant_scores": original_bounty_scores})
+            # Evaluate if original tests passed
+            original_passed = self.check_invariant_scores_against_thresholds(
+                repo_metadata_path,
+                bounty_metadata_path,
+                repo_scores_path,
+                bounty_scores_path,
+            )
 
-        # Clean up score files
-        self._cleanup_files([repo_scores_path, bounty_scores_path])
+            # Load original scores
+            original_repo_scores = self._load_json_file(repo_scores_path).get(
+                "invariant_scores", {}
+            )
+            original_bounty_scores = self._load_json_file(bounty_scores_path).get(
+                "invariant_scores", {}
+            )
 
-        # If original tests failed, try with patched unit tests
-        if not original_passed:
-            logger.info("Original tests failed, trying with patched unit tests.")
-            if self.apply_patched_unit_tests():
-                logger.info(
-                    "Unit test patches applied successfully. Running patched invariant checks."
-                )
-                # Run with patched unit tests
-                alt_repo_scores_path, alt_bounty_scores_path = (
-                    await self._execute_invariant_tests()
-                )
+            # Initialize final results
+            passed = original_passed
 
-                # Evaluate if patched tests passed
-                alt_passed = self.check_invariant_scores_against_thresholds(
-                    repo_metadata_path,
-                    bounty_metadata_path,
-                    alt_repo_scores_path,
-                    alt_bounty_scores_path,
-                )
+            all_repo_scores.append({"invariant_scores": original_repo_scores})
+            all_bounty_scores.append({"invariant_scores": original_bounty_scores})
 
-                # Load alternative scores
-                alt_repo_scores = self._load_json_file(alt_repo_scores_path).get(
-                    "invariant_scores", {}
-                )
-                alt_bounty_scores = self._load_json_file(alt_bounty_scores_path).get(
-                    "invariant_scores", {}
-                )
+            self.last_patch_agent_message.add_repo_invariant_score({"invariant_scores": original_repo_scores})
+            self.last_patch_agent_message.add_bounty_invariant_score({"invariant_scores": original_bounty_scores})
 
-                self.last_patch_agent_message.add_repo_invariant_score({"invariant_scores": alt_repo_scores})
-                self.last_patch_agent_message.add_bounty_invariant_score({"invariant_scores": alt_bounty_scores})
+            # Clean up score files
+            self._cleanup_files([repo_scores_path, bounty_scores_path])
 
-                passed = alt_passed
+            # If original tests failed, try with patched unit tests
+            if not original_passed:
+                logger.info("Original tests failed, trying with patched unit tests.")
+                if self.apply_patched_unit_tests():
+                    logger.info(
+                        "Unit test patches applied successfully. Running patched invariant checks."
+                    )
+                    # Run with patched unit tests
+                    alt_repo_scores_path, alt_bounty_scores_path = (
+                        await self._execute_invariant_tests()
+                    )
 
-                # Clean up alternative score files
-                self._cleanup_files([alt_repo_scores_path, alt_bounty_scores_path])
-            else:
-                logger.info("No unit test patches found. Skipping.")
+                    # Evaluate if patched tests passed
+                    alt_passed = self.check_invariant_scores_against_thresholds(
+                        repo_metadata_path,
+                        bounty_metadata_path,
+                        alt_repo_scores_path,
+                        alt_bounty_scores_path,
+                    )
+
+                    # Load alternative scores
+                    alt_repo_scores = self._load_json_file(alt_repo_scores_path).get(
+                        "invariant_scores", {}
+                    )
+                    alt_bounty_scores = self._load_json_file(alt_bounty_scores_path).get(
+                        "invariant_scores", {}
+                    )
+
+                    all_repo_scores.append({"invariant_scores": alt_repo_scores})
+                    all_bounty_scores.append({"invariant_scores": alt_bounty_scores})
+                    
+                    self.last_patch_agent_message.add_repo_invariant_score({"invariant_scores": alt_repo_scores})
+                    self.last_patch_agent_message.add_bounty_invariant_score({"invariant_scores": alt_bounty_scores})
+
+                    passed = alt_passed
+
+                    # Clean up alternative score files
+                    self._cleanup_files([alt_repo_scores_path, alt_bounty_scores_path])
+                else:
+                    logger.info("No unit test patches found. Skipping.")
 
         return passed
 


### PR DESCRIPTION
This PR adds logic to rerun the invariant check upon failure, with a defined `INVARIANTS_RETRY=3`. 
For each attempt, log the resulting scores. (The output of each attempt will also be captured as an action message through the `_execute_invariant_tests` function.