### PR TITLE
Rerun invariants scripts 

### DIFF
--- a/agents/patch_agent/patch_agent.py
+++ b/agents/patch_agent/patch_agent.py
@@ -597,9 +597,6 @@ bash /app/exploit.sh
         repo_metadata_path = self.task_dir / "metadata.json"
         bounty_metadata_path = self.bounty_dir / "bounty_metadata.json"
 
-        all_repo_scores = []
-        all_bounty_scores = []
-
         any_passed = False
 
         # --- Run original tests first ---
@@ -624,10 +621,6 @@ bash /app/exploit.sh
             original_bounty_scores = self._load_json_file(bounty_scores_path).get(
                 "invariant_scores", {}
             )
-
-            # Update all scores
-            all_repo_scores.append({"invariant_scores": original_repo_scores})
-            all_bounty_scores.append({"invariant_scores": original_bounty_scores})
 
             self.last_patch_agent_message.add_repo_invariant_score(
                 {"invariant_scores": original_repo_scores}
@@ -672,14 +665,11 @@ bash /app/exploit.sh
                     "invariant_scores", {}
                 )
 
-                all_repo_scores.append({"invariant_scores": alt_repo_scores})
-                all_bounty_scores.append({"invariant_scores": alt_bounty_scores})
-
                 self.last_patch_agent_message.add_repo_invariant_score(
-                    {"invariant_scores": alt_repo_scores}
+                    {"alternative_invariant_scores": alt_repo_scores}
                 )
                 self.last_patch_agent_message.add_bounty_invariant_score(
-                    {"invariant_scores": alt_bounty_scores}
+                    {"alternative_invariant_scores": alt_bounty_scores}
                 )
 
                 # Clean up alternative score files


### PR DESCRIPTION
This PR adds logic to rerun the invariant check, with a defined `INVARIANTS_RETRY=3`.
For each attempt, log the resulting scores. (The output of each attempt will also be captured as an action message through the `_execute_invariant_tests` function.
Do not break loop upon success, run `3` times regardless.

(Reopens #699 - accidentally closed)