### PR TITLE
Cleanup: Remove unnecessary set_parent

### DIFF
--- a/phases/exploit_phase.py
+++ b/phases/exploit_phase.py
@@ -168,9 +168,7 @@ class ExploitPhase(BountyPhase):
             input_list.append(previous_output)
 
         message: Message = await agent_instance.run(input_list)
-        if self._phase_message:
-            message.set_parent(self._phase_message.id)
-        logger.info(f"message parent id: {message.parent}")
+
         if isinstance(agent_instance, ExploitAgent):
             if message.success:
                 logger.status("Exploit successful!", True)

--- a/phases/patch_phase.py
+++ b/phases/patch_phase.py
@@ -184,8 +184,7 @@ class PatchPhase(BountyPhase):
             input_list.append(previous_output)
 
         message: Message = await agent_instance.run(input_list)
-        if self._phase_message:
-            message.set_parent(self._phase_message.id)
+
         if isinstance(agent_instance, PatchAgent):
             if message.success:
                 logger.info("Patch Success!")


### PR DESCRIPTION
Phase Cleanup:
`set_parent` should not need to be explicitly called in `run_one_iteration`. Added in PR #578, however, based on investigation/testing, added `set_parent` lines do not seem critical / necessary to resolve issue. 
(I believe there is another issue #721 with current phase message passing, unrelated, will open PR and add unittests confirming functionality separately)
```
  async def _run_iteration(self) -> None:
          agent_message: AgentMessage = await self.run_one_iteration(
                phase_message=self._phase_message,
                agent_instance=agent_instance,
                previous_output=self._last_agent_message,
            )
...
              self._phase_message.add_child_message(agent_message)
```
https://github.com/cybench/bountyagent/blob/main/phases/base_phase.py#L323

```
   def add_child_message(self, agent_message: AgentMessage):
        self._agent_messages.append(agent_message)
        agent_message.set_parent(self)
...
```
https://github.com/cybench/bountyagent/blob/main/messages/phase_messages/phase_message.py#L108