### PR TITLE
Cleanup: exploit, patch phase classes

### DIFF
--- a/phases/exploit_phase.py
+++ b/phases/exploit_phase.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type
 
 from agents.base_agent import AgentConfig, BaseAgent
@@ -7,14 +6,13 @@ from agents.exploit_agent.exploit_agent import ExploitAgent, ExploitAgentConfig
 from messages.message import Message
 from messages.phase_messages.phase_message import PhaseMessage
 from phases.bounty_phase import BountyPhase
+from phases.phase_utils import get_setup_resources
 from resources.base_resource import BaseResourceConfig
-from resources.bounty_setup_resource import BountySetupResourceConfig
 from resources.docker_resource import DockerResourceConfig
 from resources.init_files_resource import InitFilesResourceConfig
 from resources.kali_env_resource import KaliEnvResourceConfig
 from resources.memory_resource.memory_resource import MemoryResourceConfig
 from resources.model_resource.model_resource import ModelResourceConfig
-from resources.repo_setup_resource import RepoSetupResourceConfig
 from resources.resource_type import ResourceType
 from resources.utils import contains_setup
 from utils.logger import get_main_logger
@@ -101,44 +99,12 @@ class ExploitPhase(BountyPhase):
             (ResourceType.MEMORY, MemoryResourceConfig()),
         ]
 
-        self._add_setup_resources(resource_configs)
+        resource_configs += get_setup_resources(
+            task_dir=self.workflow.task_dir, bounty_number=self.bounty_number
+        )
 
         logger.debug(f"Exiting define_resources for ExploitPhase")
         return resource_configs
-
-    def _add_setup_resources(
-        self, resource_configs: List[Tuple[ResourceType, BaseResourceConfig]]
-    ) -> None:
-        """
-        Add setup resources to the resource configurations if setup scripts exist.
-
-        Args:
-            resource_configs (List[Tuple[DefaultResource, BaseResourceConfig]]): The current resource configurations.
-        """
-        setup_repo_env_script = self.workflow.task_dir / "setup_repo_env.sh"
-        if contains_setup(setup_repo_env_script):
-            resource_configs.append(
-                (
-                    ResourceType.REPO_SETUP,
-                    RepoSetupResourceConfig(
-                        task_dir=self.workflow.task_dir,
-                    ),
-                )
-            )
-
-        setup_bounty_env_script = (
-            self.bounty_dir / "setup_files" / "setup_bounty_env.sh"
-        )
-        if contains_setup(setup_bounty_env_script):
-            resource_configs.append(
-                (
-                    ResourceType.BOUNTY_SETUP,
-                    BountySetupResourceConfig(
-                        task_dir=self.workflow.task_dir,
-                        bounty_number=self.workflow.bounty_number,
-                    ),
-                )
-            )
 
     async def run_one_iteration(
         self,
@@ -148,12 +114,6 @@ class ExploitPhase(BountyPhase):
     ) -> Message:
         """
         Run a single iteration of the ExploitPhase.
-
-        This method performs the following steps:
-        1. Call the agent with the previous_message as input (if any).
-        2. If ExecutorAgent produces an AnswerMessageInterface, treat as hallucination -> finalize & done.
-        3. If ExploitAgent produces AnswerMessageInterface, treat as exploit success -> finalize & done.
-        4. Otherwise continue.
 
         Args:
             phase_message (PhaseMessage): The current phase message.
@@ -168,9 +128,7 @@ class ExploitPhase(BountyPhase):
             input_list.append(previous_output)
 
         message: Message = await agent_instance.run(input_list)
-        if self._phase_message:
-            message.set_parent(self._phase_message.id)
-        logger.info(f"message parent id: {message.parent}")
+
         if isinstance(agent_instance, ExploitAgent):
             if message.success:
                 logger.status("Exploit successful!", True)

--- a/phases/patch_phase.py
+++ b/phases/patch_phase.py
@@ -6,16 +6,14 @@ from agents.patch_agent.patch_agent import PatchAgent, PatchAgentConfig
 from messages.message import Message
 from messages.phase_messages.phase_message import PhaseMessage
 from phases.bounty_phase import BountyPhase
+from phases.phase_utils import get_setup_resources
 from resources.base_resource import BaseResourceConfig
-from resources.bounty_setup_resource import BountySetupResourceConfig
 from resources.docker_resource import DockerResourceConfig
 from resources.init_files_resource import InitFilesResourceConfig
 from resources.kali_env_resource import KaliEnvResourceConfig
 from resources.memory_resource.memory_resource import MemoryResourceConfig
 from resources.model_resource.model_resource import ModelResourceConfig
-from resources.repo_setup_resource import RepoSetupResourceConfig
 from resources.resource_type import ResourceType
-from resources.utils import contains_setup
 from utils.logger import get_main_logger
 from workflows.base_workflow import BaseWorkflow
 
@@ -117,44 +115,12 @@ class PatchPhase(BountyPhase):
             (ResourceType.MEMORY, MemoryResourceConfig()),
         ]
 
-        self._add_setup_resources(resource_configs)
+        resource_configs += get_setup_resources(
+            task_dir=self.workflow.task_dir, bounty_number=self.bounty_number
+        )
 
         logger.debug("Exiting define_resources for PatchPhase")
         return resource_configs
-
-    def _add_setup_resources(
-        self, resource_configs: List[Tuple[ResourceType, BaseResourceConfig]]
-    ) -> None:
-        """
-        Add setup resources to the resource configurations if setup scripts exist.
-
-        Args:
-            resource_configs (List[Tuple[DefaultResource, BaseResourceConfig]]): The current resource configurations.
-        """
-        setup_repo_env_script = self.workflow.task_dir / "setup_repo_env.sh"
-        if contains_setup(setup_repo_env_script):
-            resource_configs.append(
-                (
-                    ResourceType.REPO_SETUP,
-                    RepoSetupResourceConfig(
-                        task_dir=self.workflow.task_dir,
-                    ),
-                )
-            )
-
-        setup_bounty_env_script = (
-            self.bounty_dir / "setup_files" / "setup_bounty_env.sh"
-        )
-        if contains_setup(setup_bounty_env_script):
-            resource_configs.append(
-                (
-                    ResourceType.BOUNTY_SETUP,
-                    BountySetupResourceConfig(
-                        task_dir=self.workflow.task_dir,
-                        bounty_number=self.workflow.bounty_number,
-                    ),
-                )
-            )
 
     async def run_one_iteration(
         self,
@@ -164,12 +130,6 @@ class PatchPhase(BountyPhase):
     ) -> Message:
         """
         Run a single iteration of the PatchPhase.
-
-        This method performs the following steps:
-        1. Call the agent with previous_output as input.
-        2. If ExecutorAgent produces an AnswerMessageInterface -> hallucination -> finalize & done.
-        3. If PatchAgent produces an AnswerMessageInterface -> patch success -> finalize & done.
-        4. Otherwise continue.
 
         Args:
             phase_message (PhaseMessage): The current phase message.
@@ -184,8 +144,7 @@ class PatchPhase(BountyPhase):
             input_list.append(previous_output)
 
         message: Message = await agent_instance.run(input_list)
-        if self._phase_message:
-            message.set_parent(self._phase_message.id)
+
         if isinstance(agent_instance, PatchAgent):
             if message.success:
                 logger.info("Patch Success!")

--- a/phases/phase_utils.py
+++ b/phases/phase_utils.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from resources.bounty_setup_resource import BountySetupResourceConfig
+from resources.repo_setup_resource import RepoSetupResourceConfig
+from resources.resource_type import ResourceType
+from resources.utils import contains_setup
+
+
+def get_setup_resources(
+    task_dir: Path,
+    bounty_number: str,
+) -> None:
+    """
+    Returns setup resources configurations if setup scripts exist.
+    """
+    setup_resource_list = []
+    setup_repo_env_script = task_dir / "setup_repo_env.sh"
+    if contains_setup(setup_repo_env_script):
+        setup_resource_list.append(
+            (
+                ResourceType.REPO_SETUP,
+                RepoSetupResourceConfig(
+                    task_dir=task_dir,
+                ),
+            )
+        )
+
+    setup_bounty_env_script = (
+        f"bounties/bounty_{bounty_number}" / "setup_files" / "setup_bounty_env.sh"
+    )
+    if contains_setup(setup_bounty_env_script):
+        setup_resource_list.append(
+            (
+                ResourceType.BOUNTY_SETUP,
+                BountySetupResourceConfig(
+                    task_dir=task_dir,
+                    bounty_number=bounty_number,
+                ),
+            )
+        )
+
+    return setup_resource_list


### PR DESCRIPTION
This PR moves getting setup resource configs to shared helper function between phases. 
Also removes outdated, incorrect comments on what success conditions are used for phases, e.g.
```
        This method performs the following steps:
        1. Call the agent with the previous_message as input (if any).
        2. If ExecutorAgent produces an AnswerMessageInterface, treat as hallucination -> finalize & done.
        3. If ExploitAgent produces AnswerMessageInterface, treat as exploit success -> finalize & done.
        4. Otherwise continue.
```