### PR TITLE
fix path to correctly import bounty env script

### DIFF
--- a/phases/phase_utils.py
+++ b/phases/phase_utils.py
@@ -25,7 +25,10 @@ def get_setup_resources(
             )
         )
 
-    setup_bounty_env_script = Path(f"bounties/bounty_{bounty_number}") / "setup_files" / "setup_bounty_env.sh"
+    setup_bounty_env_script = (
+        task_dir / "bounties" / f"bounty_{bounty_number}" / "setup_files" / "setup_bounty_env.sh"
+    )
+
     if contains_setup(setup_bounty_env_script):
         setup_resource_list.append(
             (


### PR DESCRIPTION
There's an issue with correct bounty setup on main. Currently the path to get the setup_bounty_env_script is incorrect so we can't correctly get the script. Therefore the bounty environment doesn't get setup correctly. This fix makes sure we are correctly importing the bounty env 