### PR TITLE
Fix action_message additional_metadata format

### DIFF
--- a/messages/action_messages/action_message.py
+++ b/messages/action_messages/action_message.py
@@ -13,7 +13,11 @@ class ActionMessage(Message):
     ) -> None:
         self._resource_id = resource_id
         self._message = message
-        self._additional_metadata = additional_metadata or {}
+        self._additional_metadata = (
+            additional_metadata[0] if isinstance(additional_metadata, tuple) and additional_metadata
+            else additional_metadata if isinstance(additional_metadata, dict)
+            else {}
+        )
         self._memory = None
 
         super().__init__(prev)
@@ -47,10 +51,10 @@ class ActionMessage(Message):
         return "ActionMessage"
 
     @property
-    def additional_metadata(self) -> str:
+    def additional_metadata(self) -> Dict[str, Any]:
         return self._additional_metadata
 
-    def add_to_additional_metadata(self, key: str, value: Any) -> str:
+    def add_to_additional_metadata(self, key: str, value: Any) -> None:
         self._additional_metadata[key] = value
 
     @property


### PR DESCRIPTION
In resources/model_resource/model_resource.py, (https://github.com/cybench/bountyagent/blob/9f6b5bf01bd4fdf1ed77aa2c1e9cd16f851f2ca2/resources/model_resource/model_resource.py#L229C9-L229C18), additional_metadata is created as a tuple, so when an ActionMessage is generated from the model output, its additional_metadata is set as a tuple rather than a dictionary, which makes it non-modifiable. This PR fixes the issue.