### PR TITLE
Make workflow UI's default max output token change based on model

### DIFF
--- a/frontend/src/components/WorkflowLauncher/WorkflowLauncher.jsx
+++ b/frontend/src/components/WorkflowLauncher/WorkflowLauncher.jsx
@@ -115,7 +115,7 @@ export const WorkflowLauncher = ({ onWorkflowStart, interactiveMode, setInteract
       model: defaultModel ? defaultModel.name : '',
       use_helm: isHelmModel,
       use_mock_model: prev.use_mock_model, // Preserve mock model selection
-      max_output_tokens: defaultModel ? getDefaultMaxOutputTokens(defaultModel ? defaultModel.name : '', isHelmModel).toString() : '',
+      max_output_tokens: getDefaultMaxOutputTokens(defaultModel?.name, isHelmModel).toString(),
     }));
   };
 
@@ -163,7 +163,7 @@ export const WorkflowLauncher = ({ onWorkflowStart, interactiveMode, setInteract
         ...prev,
         model: defaultModel ? defaultModel.name : '',
         use_helm: isHelmModel,
-        max_output_tokens: defaultModel ? getDefaultMaxOutputTokens(defaultModel ? defaultModel.name : '', isHelmModel).toString() : ''
+        max_output_tokens: getDefaultMaxOutputTokens(defaultModel?.name, isHelmModel).toString(),
       }));
     } catch (err) {
       setLauncherState({

--- a/frontend/src/token_default_config.js
+++ b/frontend/src/token_default_config.js
@@ -27,8 +27,8 @@ export const MODEL_DEFAULTS_NON_HELM = {
     "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": 2048, 
     "meta-llama/Meta-Llama-3-70B-Instruct-Turbo": 2048,
     // Together Models (DeepSeek)
-    "deepseek-ai/deepseek-v3": 8192, 
-    "deepseek-ai/deepseek-r1": 8192,
+    "deepseek-ai/deepseek-v3": 32768, 
+    "deepseek-ai/deepseek-r1": 32768,
     // Mistral Models
     "mistralai/mixtral-8x22b-instruct-v0.1": 4096, 
 };
@@ -59,9 +59,9 @@ export const MODEL_DEFAULTS_HELM = {
     "meta/llama-3.1-70b-instruct-turbo": 2048, 
     "meta/llama-3.1-405b-instruct-turbo": 2048, 
     // Together Models (DeepSeek)
-    "deepseek-ai/deepseek-v3": 8192, 
-    "deepseek-ai/deepseek-r1": 8192, 
-    "deepseek-ai/deepseek-r1-hide-reasoning": 8192, 
+    "deepseek-ai/deepseek-v3": 32768, 
+    "deepseek-ai/deepseek-r1": 32768, 
+    "deepseek-ai/deepseek-r1-hide-reasoning": 32768, 
     // Mistral Models
     "mistralai/mistral-large-2407": 4096, 
     "mistralai/mixtral-8x22b": 4096, 


### PR DESCRIPTION
This commit changes the maximum output token from 4096 (independent of the model) to a value dependent on the model name and whether it uses HELM. This change increases user friendliness when setting the max output token value in the workflow UI. 