### PR TITLE
Add timeout to docker run in docker_resource.py

### DIFF
--- a/resources/docker_resource.py
+++ b/resources/docker_resource.py
@@ -108,7 +108,6 @@ class DockerResource(RunnableBaseResource):
             f"{command[:10]}...{command[-10:]}" if len(command) > 23 else command
         )
 
-        # Thread-safe way to enable real-time logging while preventing hanging
         def stream_logs(container, logs, stop_event):
             try:
                 for line in container.logs(stdout=True, stderr=True, stream=True):
@@ -134,6 +133,7 @@ class DockerResource(RunnableBaseResource):
 
             logger.info("Container started. Streaming logs...")
 
+            # Thread-safe way to enable real-time logging while preventing hanging
             logs = []
             stop_event = threading.Event()
             log_thread = threading.Thread(target=stream_logs, args=(container, logs, stop_event))


### PR DESCRIPTION
Right now there is no timeout enforcement with executing in docker inside docker_resource.py, which causes certain script executions on the agent side such as the agent-generated exploit.sh to hang forever in the logging step. This adds a thread-safe way to enable real-time logging while preventing hanging, enforcing that execution finishes within designated time limit (2 min e.g.).