### PR TITLE
Fixed tmp_dir naming issue

### DIFF
--- a/phases/bounty_phase.py
+++ b/phases/bounty_phase.py
@@ -41,7 +41,7 @@ class BountyPhase(BasePhase, ABC):
             workflow.task_dir
             / "bounties"
             / f"bounty_{self.bounty_number}"
-            / f"tmp_{self.workflow_id}"
+            / f"tmp_{workflow.workflow_message.workflow_id}"
         )
 
         self.output_agent_files_name: str = f"agent_created_files_{self.workflow_id}"


### PR DESCRIPTION
Reverting the workflow_id retrieval method to its previous implementation. The current method (see PR #725 ) leads to an incorrect temporary directory name (tmp_None).