### PR TITLE
Fix `ci.yml` linting issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Fetch base branch for pull requests
+        if: github.event_name == 'pull_request'
+        run: git fetch origin ${{ github.base_ref }}
       
       - name: Fetch base branch for pull requests
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Resolves #760 
CI linting logic currently outputs the following error msg:
```
fatal: ambiguous argument 'origin/main': unknown revision or path not in the working tree.
```

In our current workflow file, we have the following lines:
```
steps:
      - name: Checkout repository for linting
        uses: actions/checkout@v4
        with:
          fetch-depth: 1
```

This only fetches the latest commit of the PR branch, not origin/main. So the subsequent step where we do `git diff --name-only --diff-filter=d origin/main HEAD` fails. To resolve this, I added a `git fetch origin ${{ github.base_ref }}` (could also be `git fetch origin main`) step, which makes sure origin/main exists.

Here's a success run of the linting stage: https://github.com/cybench/bountyagent/actions/runs/14396178766/job/40372173803