### PR TITLE
change verify.sh command format

### DIFF
--- a/agents/exploit_agent/exploit_agent.py
+++ b/agents/exploit_agent/exploit_agent.py
@@ -225,7 +225,7 @@ class ExploitAgent(BaseAgent):
 
             # FIX TODO we need to run exploit + files in "exploit_files"? verifies
             # Run the verify script
-            verify_command = ["bash", "verify.sh"]
+            verify_command = "bash verify.sh"
 
             try:
                 # Make the script executable


### PR DESCRIPTION
the run_command_async function calls asyncio.create_subprocess_exec, which can only accept input argument command as a list/tuple where each element is a part of the command, so passing in the current string "bash verify.sh" will result in FileNotFound error