### PR TITLE
Add exploit script output to the exploit agent message

### DIFF
--- a/tests/agents/test_exploit_agent.py
+++ b/tests/agents/test_exploit_agent.py
@@ -118,13 +118,9 @@ async def test_run_command_async_error(exploit_agent):
             side_effect=Exception("fail"),
         ),
         patch.object(exploit_agent, "restart_resources", return_value=True),
-        patch("logging.getLogger", return_value=MagicMock()),
     ):
-        # Suppress any output during test
-        with pytest.capture_stdout() as stdout:
-            result = await exploit_agent._run_exploit_verify()
-            assert result is None
-            assert stdout.read() == ""
+        result = await exploit_agent._run_exploit_verify()
+        assert result is None
 
 
 def test_apply_patch_to_bounty_success(agent_config):


### PR DESCRIPTION
Currently, we put outputs from exploit.sh / verify.sh to the exploit agent message. One note is that we might need to cleanup some verify scripts to ensure that we do not leak any information.