### PR TITLE
Print entire executed command in `DockerResource`

### DIFF
--- a/resources/docker_resource.py
+++ b/resources/docker_resource.py
@@ -107,9 +107,6 @@ class DockerResource(RunnableBaseResource):
         """
 
         unique_name = f"{self.resource_id}-{uuid.uuid4().hex[:10]}"
-        command_trc = (
-            f"{command[:10]}...{command[-10:]}" if len(command) > 23 else command
-        )
 
         def stream_logs(container, logs, stop_event):
             try:
@@ -122,7 +119,7 @@ class DockerResource(RunnableBaseResource):
             except Exception as e:
                 logger.warning(f"Log stream ended: {e}")
 
-        logger.info(f"Running command in Docker: {command_trc}")
+        logger.info(f"Running command in Docker: {command}")
         try:
             container = self.client.containers.run(
                 image=docker_image,


### PR DESCRIPTION
Truncated command was not very helpful for debugging what's going on - is it possible to print the command in its entirety? If there's a special reason I'll find a workaround!

<img width="831" alt="image" src="https://github.com/user-attachments/assets/20ce92a0-87aa-46c4-8fa7-be9ef8d4ef31" />

