### PR TITLE
change default docker_resource timeout to 5 minutes

### DIFF
--- a/resources/docker_resource.py
+++ b/resources/docker_resource.py
@@ -88,7 +88,7 @@ class DockerResource(RunnableBaseResource):
         work_dir: str = None,
         volumes: dict = None,
         detach: bool = False,
-        timeout: int = 180,  # timeout in seconds (default: 3 minutes)
+        timeout: int = 300,  # timeout in seconds (default: 5 minutes)
     ) -> tuple:
         """
         Run a Docker container with the specified configuration.
@@ -100,7 +100,7 @@ class DockerResource(RunnableBaseResource):
             work_dir (Optional[str]): The working directory inside the container.
             volumes (Optional[dict]): The volumes to mount in the container.
             detach (bool): Run the container in detached mode. Defaults to False.
-            timeout (int): Time in seconds before killing the container. Defaults to 180.
+            timeout (int): Time in seconds before killing the container. Defaults to 300.
 
         Returns:
             tuple: A tuple containing the logs from the container and the exit code.


### PR DESCRIPTION
From running certain bounties, it seems that some exploits/servers might take longer to respond and changing from 120s to 180s seems to provide more robust results
