### PR TITLE
Exploit Agent: Commit exploit_files changes

### DIFF
--- a/agents/exploit_agent/exploit_agent.py
+++ b/agents/exploit_agent/exploit_agent.py
@@ -1,7 +1,7 @@
+import shutil
 import time
 from dataclasses import dataclass
 from pathlib import Path
-import shutil
 from typing import List, Optional
 
 from tenacity import retry, stop_after_attempt, wait_fixed
@@ -10,11 +10,12 @@ from agents.base_agent import AgentConfig, BaseAgent, IterationFailure
 from messages.action_messages.docker_action_message import DockerActionMessage
 from messages.action_messages.script_action_message import ScriptActionMessage
 from messages.agent_messages.agent_message import AgentMessage
-from messages.agent_messages.exploit_agent_message import ExploitAgentMessage
 from messages.agent_messages.executor_agent_message import ExecutorAgentMessage
+from messages.agent_messages.exploit_agent_message import ExploitAgentMessage
 from resources.base_resource import ActionMessage
 from resources.resource_type import ResourceType
 from resources.utils import run_command_async
+from utils.file_utils import apply_patch_to_bounty
 from utils.git_utils import (
     git_clean,
     git_commit,
@@ -23,7 +24,6 @@ from utils.git_utils import (
     git_reset,
 )
 from utils.logger import get_main_logger
-from utils.file_utils import apply_patch_to_bounty
 
 logger = get_main_logger(__name__)
 
@@ -156,7 +156,7 @@ class ExploitAgent(BaseAgent):
             return self._update_exploit_agent_message()
 
         # Commit the state of the exploit_files_dir (exploit files)
-        git_commit(self.exploit_files_dir)
+        git_commit(self.tmp_dir, subfolder_to_commit=self.exploit_files_dir)
 
         try:
             await self.validate_exploit_script()
@@ -182,10 +182,14 @@ class ExploitAgent(BaseAgent):
         exit_code = await self._run_exploit_verify()
 
         if exit_code != 0:
-            self._log_step("Exploit verification failed before vulnerability was patched.")
+            self._log_step(
+                "Exploit verification failed before vulnerability was patched."
+            )
             return
 
-        self._log_step("Exploit verification succeeded before vulnerability was patched.")
+        self._log_step(
+            "Exploit verification succeeded before vulnerability was patched."
+        )
 
         try:
             task_dir_success = apply_patch_to_bounty(self.bounty_dir, self.task_dir)
@@ -355,8 +359,12 @@ bash /app/exploit_files/exploit.sh
             self._remove_verify_files(self.verify_files_dir)
         orig_verify_files_dir = self.bounty_dir / "verify_files"
         if not orig_verify_files_dir.exists():
-            logger.warning(f"Verify files directory not found at {orig_verify_files_dir}")
-            raise Exception(f"Verify files directory not found at {orig_verify_files_dir}")
+            logger.warning(
+                f"Verify files directory not found at {orig_verify_files_dir}"
+            )
+            raise Exception(
+                f"Verify files directory not found at {orig_verify_files_dir}"
+            )
         self._copy_verify_files(orig_verify_files_dir, self.verify_files_dir)
 
     #### HELPER FUNCTIONS ####

--- a/utils/git_utils.py
+++ b/utils/git_utils.py
@@ -69,6 +69,7 @@ def git_commit(
     directory_path: PathLike,
     commit_message: Optional[Union[str, int, float]] = None,
     branch_name: Optional[str] = None,
+    subfolder_to_commit: Optional[PathLike] = None,
 ) -> bool:
     """
     Create a git commit with all changes in the repository.
@@ -102,8 +103,12 @@ def git_commit(
         if branch_name:
             _checkout_branch(directory, branch_name)
 
-        # Stage all changes
-        _run_git_command(directory, ["add", "."])
+        # Stage changes
+        if subfolder_to_commit:
+            relative_path = str(subfolder_to_commit.relative_to(directory))
+            _run_git_command(directory, ["add", relative_path])
+        else:
+            _run_git_command(directory, ["add", "."])
 
         # Check repository status
         if not git_has_changes(directory):
@@ -573,19 +578,19 @@ def initialize_git_repository(destination):
 
 def delete_git_branches(destination, exclude_branches=None):
     """Delete Git branches in the repository.
-    
+
     Args:
         destination: Path to the Git repository
         exclude_branches: List of branch names to exclude from deletion (default: None)
-        
+
     Returns:
         List of successfully deleted branch names
     """
     if exclude_branches is None:
         exclude_branches = []
-    
+
     deleted_branches = []
-    
+
     # Get all branches
     result = subprocess.run(
         ["git", "branch"],
@@ -620,7 +625,7 @@ def delete_git_branches(destination, exclude_branches=None):
             deleted_branches.append(branch)
         except subprocess.CalledProcessError as e:
             logger.warning(f"Failed to delete branch {branch}: {e}")
-            
+
     return deleted_branches
 
 


### PR DESCRIPTION
`git_commit(self.exploit_files_dir)` fails every time, because `exploit_files` is not a git repo. Instead, we want to be adding and committing `exploit_files` via `git_commit(self.tmp_dir, subfolder_to_commit=self.exploit_files_dir)`

Previously, no git repo would be found at `exploit_files`, so changes would not be committed and cleanup would include:
```
warning: failed to remove exploit_files/exploit.sh: Permission denied
2025-04-15 18:32:56 WARNING  [utils/git_utils.py:36]
Git command failed: git clean -fd - Command '['git', 'clean', '-fd']' returned non-zero exit status 1.
```
Now changes are successfully committed:
```
2025-04-15 19:05:23 INFO     [agents/exploit_agent/exploit_agent.py:327]
Exploit script found.
2025-04-15 19:05:23 INFO     [utils/git_utils.py:33]
Git command succeeded: git status --porcelain
2025-04-15 19:05:23 INFO     [utils/git_utils.py:33]
Git command succeeded: git add exploit_files
2025-04-15 19:05:23 INFO     [utils/git_utils.py:33]
Git command succeeded: git status --porcelain
[main bab471a] Update files at 2025-04-15 19:05:23
 1 file changed, 26 insertions(+)
 create mode 100644 exploit_files/exploit.sh
2025-04-15 19:05:23 INFO     [utils/git_utils.py:33]
Git command succeeded: git commit -m Update files at 2025-04-15 19:05:23
2025-04-15 19:05:23 INFO     [utils/git_utils.py:116]
Commit 'Update files at 2025-04-15 19:05:23' created successfully
```
