### PR TITLE
Prohibit LMs from modifying test files in PatchPhase

### DIFF
--- a/agents/patch_agent/patch_agent.py
+++ b/agents/patch_agent/patch_agent.py
@@ -855,7 +855,7 @@ bash /app/exploit.sh
         """
         sanitized_diff = []
         skip_block = False
-        block_lines = original_diff.splitlines()
+        block_lines = (original_diff or "").splitlines()
 
         for line in block_lines:
             if line.startswith("diff --git"):

--- a/tests/agents/test_patch_agent.py
+++ b/tests/agents/test_patch_agent.py
@@ -570,7 +570,7 @@ async def test_reset_repo_on_empty_diff(patch_agent, mocker):
     agent = patch_agent
     prev_patch_id = agent.patch_id
 
-    mocker.patch("agents.patch_agent.patch_agent.git_diff", return_value=None)
+    mocker.patch("agents.patch_agent.patch_agent.git_diff", return_value="")
     mocker.patch.object(patch_agent, "run_external_exploit", return_value=0)
     mocker.patch(
         "agents.patch_agent.patch_agent.git_apply_patch",


### PR DESCRIPTION
Please provide a clear and concise description of the changes in this PR. Highlight the purpose and context of the modifications.

### Description
- [ ] **Why are these changes needed?/Changes made** 

Recent runs with o3 showed that the LM looked into the related unit tests corresponding to the vulnerable feature. If the agent decides to change the unit tests within the codebase, such action should not be allowed.

See patch workflow logs below for detail

https://drive.google.com/file/d/1UU7O3fGP7RryG6kA94kTxRw5KBPvTWRT/view?usp=sharing
https://drive.google.com/file/d/1UtOU4PGI9cf6XveOwzqb8DN7HAt--8Ri/view?usp=sharing

- [ ] **What does this PR do?** 

This PR is an attempt to use a set of heuristics to determine if any files in picked up by `git diff` in `PatchAgent` is a test file. If so, remove them from the diff so that the LMs do not actually modify test files even if they attempt so.

Thought Process Behind this PR:
- The proposed string-parsing-based approach to detect test files/folders is akin to how test libraries like pytest discovers test directories / files.
- The next best thing may be adding `.gitignore` for folders containing "tests" etc., but .gitignore is less versatile than the current string parsing. The current string parsing solution is also able to inform the LM that it should not attempt to change test files upon such attempts.
- Alternatively, we can ask bounty adders to add test files/directories that we should protect via a key in `metadata.json` , but this can be quite a bit of nontrivial work for the bounty adders and there lacks a way in our automated CI to check whether these protected files/directories are correct/comprehensive.

### Checklist (Review before submitting)
- [ ] **Unit Tests:**
  - Include test cases for new code or functionality.
  - Ensure all tests pass by running the test suite.
- [ ] **Documentation:**
  - Add or update inline comments where applicable.
  - Update any relevant README or documentation files.
- [ ] **Peer Review:**
  - The PR must be reviewed by at least one team member before merging.

### Linked Issues
- Resolves #788 

### Additional Notes
Add any additional context, screenshots, or details that may assist the reviewer.
