### PR TITLE
fix disable next behavior in AgentInteractions.jsx

### DIFF
--- a/frontend/src/components/AgentInteractions/AgentInteractions.jsx
+++ b/frontend/src/components/AgentInteractions/AgentInteractions.jsx
@@ -25,6 +25,7 @@ const AgentInteractions = ({
   const [selectedCellId, setSelectedCellId] = useState(null);
   const [selectedIterNum, setSelectedIterNum] = useState(1);
   const [selectedIterType, setSelectedIterType] = useState('agent');
+  const [responding, setResponding] = useState(false);
 
   const handleInputChange = (event) => {
     const value = parseInt(event.target.value, 10);
@@ -52,6 +53,7 @@ const AgentInteractions = ({
 
   useEffect(() => {
     console.log('Phase Messages updated:', phaseMessages);
+    setResponding(false);
   }, [phaseMessages]);
 
   const handleStopClick = async () => {
@@ -59,6 +61,12 @@ const AgentInteractions = ({
     await onStopWorkflow();
     setStopped(true);
   };
+
+  const handleContinueClick = () => {
+    setResponding(true);  // Disable the button immediately
+    onTriggerNextIteration(selectedIterNum, selectedIterType);  // Trigger the next iteration
+  };
+
 
   const handleRestart = async () => {
     await onRestart();
@@ -84,6 +92,8 @@ const AgentInteractions = ({
       </Box>
     );
   }
+
+  const isDisabled = isNextDisabled || responding;
 
   return (
     <Box className="interactions-container">
@@ -131,9 +141,9 @@ const AgentInteractions = ({
             <Button
               variant="contained"
               color="primary"
-              onClick={() => onTriggerNextIteration(selectedIterNum, selectedIterType)}
+              onClick={handleContinueClick}
               startIcon={<KeyboardDoubleArrowRightIcon />}
-              disabled={isNextDisabled}
+              disabled={isDisabled}
               size="small"
             >
               Continue


### PR DESCRIPTION
currently, since the triggerNextIteration function set off by the continue button is nonblocking, isNextDisabled is set to True when the button is clicked but then immediately reverts back to False after the next_iteration call gets added to the workflow's next_iteration_queue without waiting for it to finish. In this way, the continue button will not get properly disabled, allowing it to be clicked even though responses are still being generated in the current iteration.  This fixes the continue button not being properly disabled behavior and only allows the continue button to work when a given iteration finishes, i.e., when the phase messages update