### PR TITLE
Fix KeyError in get_workflow_resources when workflow is initializing

### DIFF
--- a/backend/execution_backends/local_execution_backend.py
+++ b/backend/execution_backends/local_execution_backend.py
@@ -467,6 +467,10 @@ class LocalExecutionBackend(ExecutionBackend):
         """
         if workflow_id not in self.active_workflows:
             return {"error": f"Workflow {workflow_id} not found"}
+        
+        if "instance" not in self.active_workflows[workflow_id]:
+            return {"error": f"Workflow {workflow_id} is initializing, instance not ready yet"}
+
 
         workflow = self.active_workflows[workflow_id]["instance"]
         resource_manager = workflow.resource_manager


### PR DESCRIPTION
The get_workflow_resources method was failing with a KeyError: 'instance' when accessing resources for a workflow that was still in the initialization phase.  This occurs in a race condition where the frontend requests resources immediately  after a WebSocket connection establishes the workflow entry, but before the workflow instance is fully created.

Added a check to verify if the "instance" key exists in the workflow dictionary  before attempting to access it. If the instance doesn't exist yet, the method now returns an appropriate error message indicating the workflow is still initializing,  rather than crashing with a KeyError.

Error:
```

[server]   File "/Users/riyadulepet/Desktop/stanford/latest_bountyagent/bountyagent/backend/routers/workflow_service.py", line 116, in get_workflow_resources
[server]     result = await execution_backend.get_workflow_resources(workflow_id)
[server]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[server]   File "/Users/riyadulepet/Desktop/stanford/latest_bountyagent/bountyagent/backend/execution_backends/local_execution_backend.py", line 471, in get_workflow_resources
[server]     workflow = self.active_workflows[workflow_id]["instance"]
[server]                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
[server] KeyError: 'instance'
[server] INFO:     127.0.0.1:55543 - "GET /workflow/4393601296/resources HTTP/1.1" 500 Internal Server Error
[server] ERROR:    Exception in ASGI application
[server] Traceback (most recent call last):
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
[server]     result = await app(  # type: ignore[func-returns-value]
[server]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
[server]     return await self.app(scope, receive, send)
[server]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
[server]     await super().__call__(scope, receive, send)
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/applications.py", line 113, in __call__
[server]     await self.middleware_stack(scope, receive, send)
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/middleware/errors.py", line 187, in __call__
[server]     raise exc
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/middleware/errors.py", line 165, in __call__
[server]     await self.app(scope, receive, _send)
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/middleware/cors.py", line 93, in __call__
[server]     await self.simple_response(scope, receive, send, request_headers=headers)
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/middleware/cors.py", line 144, in simple_response
[server]     await self.app(scope, receive, send)
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
[server]     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
[server]     raise exc
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
[server]     await app(scope, receive, sender)
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/routing.py", line 715, in __call__
[server]     await self.middleware_stack(scope, receive, send)
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/routing.py", line 735, in app
[server]     await route.handle(scope, receive, send)
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/routing.py", line 288, in handle
[server]     await self.app(scope, receive, send)
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/routing.py", line 76, in app
[server]     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
[server]     raise exc
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
[server]     await app(scope, receive, sender)
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/starlette/routing.py", line 73, in app
[server]     response = await f(request)
[server]                ^^^^^^^^^^^^^^^^
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/fastapi/routing.py", line 301, in app
[server]     raw_response = await run_endpoint_function(
[server]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[server]   File "/Users/riyadulepet/anaconda3/envs/bountyagent/lib/python3.11/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
[server]     return await dependant.call(**values)
[server]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[server]   File "/Users/riyadulepet/Desktop/stanford/latest_bountyagent/bountyagent/backend/routers/workflow_service.py", line 116, in get_workflow_resources
[server]     result = await execution_backend.get_workflow_resources(workflow_id)
[server]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[server]   File "/Users/riyadulepet/Desktop/stanford/latest_bountyagent/bountyagent/backend/execution_backends/local_execution_backend.py", line 471, in get_workflow_resources
[server]     workflow = self.active_workflows[workflow_id]["instance"]
[server]                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
```