### PR TITLE
Adapted kali_env_resource.py to take an optional is_python input

### DIFF
--- a/phases/detect_phase.py
+++ b/phases/detect_phase.py
@@ -96,6 +96,7 @@ class DetectPhase(BountyPhase):
                     },
                     target_hosts=target_hosts,
                     install_command=self.workflow.repo_metadata.get("install_command"),
+                    is_python=self.workflow.repo_metadata.get("is_python"),
                 ),
             ),
             (ResourceType.DOCKER, DockerResourceConfig()),

--- a/phases/exploit_phase.py
+++ b/phases/exploit_phase.py
@@ -114,6 +114,7 @@ class ExploitPhase(BountyPhase):
                     },
                     target_hosts=target_hosts,
                     install_command=self.workflow.repo_metadata.get("install_command"),
+                    is_python=self.workflow.repo_metadata.get("is_python"),
                 ),
             ),
             (ResourceType.DOCKER, DockerResourceConfig()),

--- a/phases/patch_phase.py
+++ b/phases/patch_phase.py
@@ -113,6 +113,7 @@ class PatchPhase(BountyPhase):
                     },
                     target_hosts=target_hosts,
                     install_command=self.workflow.repo_metadata.get("install_command"),
+                    is_python=self.workflow.repo_metadata.get("is_python"),
                 ),
             ),
             (ResourceType.DOCKER, DockerResourceConfig()),

--- a/resources/kali_env_resource.py
+++ b/resources/kali_env_resource.py
@@ -73,6 +73,7 @@ class KaliEnvResourceConfig(BaseResourceConfig):
     volumes: Optional[Dict[str, Dict[str, str]]] = None
     target_hosts: Optional[List[str]] = None
     install_command: Optional[str] = None
+    is_python: Optional[bool] = None
     disable_cleanup: Optional[bool] = None
 
     def validate(self) -> None:
@@ -99,6 +100,7 @@ class KaliEnvResource(RunnableBaseResource):
         self.util.validate_container_status(self.container, logger)
         self.target_hosts = self._resource_config.target_hosts
         self.install_command = self._resource_config.install_command
+        self.is_python = self._resource_config.is_python
         self.disable_cleanup = self._resource_config.disable_cleanup
         self.socket = None  # Socket for writing to the pseudo-terminal
         self._initialize_bounty_directory()
@@ -312,6 +314,8 @@ class KaliEnvResource(RunnableBaseResource):
 
     def _is_python_repo(self, codebase_path):
         """Check if the repository is a Python repository by looking for setup.py or pyproject.toml"""
+        if self.is_python is not None:
+            return self.is_python
         cmd = f"ls {codebase_path}/setup.py {codebase_path}/pyproject.toml 2>/dev/null || true"
         stdout, _ = self.run_command(cmd, TIMEOUT_PER_COMMAND)
         return "setup.py" in stdout or "pyproject.toml" in stdout


### PR DESCRIPTION
This PR mainly changes the kali_env_resource.py file, enabling it to deal with an is_python input.

This is needed for the node repo, because it has a pyproject.toml file. Thus, the _is_python() function returns true, even though node is not a Python project. 
This causes the node workflow to run into issues when executing "git_commit(host_path)", resulting in the following error: 
"Git command failed: git add . - Command '['git', 'add', '.']' returned non-zero exit status 1."

By including logic to take an "is_python" input, we can avoid this issue and treat node as not a Python project.
