### PR TITLE
Change docker_resource default timeout from 300 to 600 seconds

### DIFF
--- a/resources/docker_resource.py
+++ b/resources/docker_resource.py
@@ -88,7 +88,7 @@ class DockerResource(RunnableBaseResource):
         work_dir: str = None,
         volumes: dict = None,
         detach: bool = False,
-        timeout: int = 600,  # timeout in seconds (default: 5 minutes)
+        timeout: int = 600,  # timeout in seconds (default: 10 minutes)
     ) -> tuple:
         """
         Run a Docker container with the specified configuration.


### PR DESCRIPTION
Scikit-learn bounty 0's exploit takes longer than 300 seconds. Increasing the timeout will accommodate bounties with scripts needing more time to execute. 

Increased it to 600 seconds following a previous discussion on this issue (https://github.com/cybench/bountyagent/pull/807).
