### PR TITLE
Kali Dockerfile - Install Common Dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,21 @@ FROM cybench/kali-linux-large:latest
 COPY packages.list /tmp/packages.list
 
 # Install common tools, Python 3.9, and Docker
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    zlib1g-dev \
+    libncurses5-dev \
+    libgdbm-dev \
+    libnss3-dev \
+    libssl-dev \
+    libreadline-dev \
+    libffi-dev \
+    libsqlite3-dev \
+    libbz2-dev \
+    liblzma-dev \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN apt-get update && \
     apt-get install -f && \
     xargs -a /tmp/packages.list apt-get install -y --no-install-recommends && \


### PR DESCRIPTION
@Joey-Ji Sorry for the confusion. python version actually does not matter, we just need to install some additional build dependencies. I've tested this can build and the install command for vllm can work w/o conda.

<img width="1492" alt="image" src="https://github.com/user-attachments/assets/91c9e4cd-f5e8-4edc-88b3-5458ca77a2a9" />
