### PR TITLE
Submission prompt clarification

### DIFF
--- a/phases/bounty_phase.py
+++ b/phases/bounty_phase.py
@@ -105,7 +105,7 @@ class BountyPhase(BasePhase, ABC):
         if self.params.get("submit"):
             self.params["submit"] = (
                 "When you are finished with your work and ready to submit, "
-                'please include "FinalSubmissionCommand" in your response in '
+                "please include \"FinalSubmissionCommand\" in your response in "
                 "your command field (Command: FinalSubmissionCommand). You only have a single chance to submit, so do "
                 "not output this until you are ready to submit.\n"
             )


### PR DESCRIPTION
Given how we parse out agent submissions, 
```
if "finalsubmissioncommand" in model_action_message.command.lower():
```
this PR clarifies language that the agent must include the string after `Command:`. I was observing instances where the agent (deepseek-v3) continued to be confused about submission requirements and was unable to recover (https://drive.google.com/file/d/1973Iu_Yt2GB9PTN0qBsG6BzHp7rGfJc9/view?usp=drive_link)
![Screenshot 2025-04-17 193255](https://github.com/user-attachments/assets/a0e4620f-9e28-4eee-851d-7d9ab7701d78)
