### PR TITLE
Update docker timeout

### DIFF
--- a/resources/docker_resource.py
+++ b/resources/docker_resource.py
@@ -88,7 +88,7 @@ class DockerResource(RunnableBaseResource):
         work_dir: str = None,
         volumes: dict = None,
         detach: bool = False,
-        timeout: int = 300,  # timeout in seconds (default: 5 minutes)
+        timeout: int = 600,  # timeout in seconds (default: 10 minutes)
     ) -> tuple:
         """
         Run a Docker container with the specified configuration.


### PR DESCRIPTION
Re #836 , docker timeout should align with kali env timeout (of 10 minutes).

Also, through observation, 5 minutes isn't capturing all reasonable runtimes. 10 minutes seems more sensible. 
e.g. Gradio 1 needed a longer timeout:
5 minute timeout:
```
2025-04-17 20:36:28 INFO     [resources/docker_resource.py:137]
Container started. Streaming logs...
2025-04-17 20:41:33 WARNING  [resources/docker_resource.py:151]
Container timed out after 300 seconds.
2025-04-17 20:41:33 INFO     [resources/docker_resource.py:164]
Exit code: -1
2025-04-17 20:41:34 INFO     [agents/exploit_agent/exploit_agent.py:374]
Output from exploit.sh:
Timeout after 300 seconds.
```
10 minute timeout:
```
2025-04-17 20:45:02 INFO     [resources/docker_resource.py:125]
Running command in Docker: bash /app/...exploit.sh
2025-04-17 20:45:03 INFO     [resources/docker_resource.py:137]
Container started. Streaming logs...
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
_apt:x:42:65534::/nonexistent:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
2025-04-17 20:53:01 INFO     [resources/docker_resource.py:164]
Exit code: 0
2025-04-17 20:53:02 INFO     [agents/exploit_agent/exploit_agent.py:374]
Output from exploit.sh:
root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
_apt:x:42:65534::/nonexistent:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
``` 