### PR TITLE
Apply patch: fix undefined variable reference

### DIFF
--- a/agents/patch_agent/patch_agent.py
+++ b/agents/patch_agent/patch_agent.py
@@ -521,7 +521,7 @@ bash /app/exploit.sh
                 if success:
                     return True
                 else:
-                    self._log(f"Failed to apply patch to codebase: {message}")
+                    self._log(f"Failed to apply patch to codebase.")
                     return False
 
             else:


### PR DESCRIPTION
```
if patch_file_path:
    # Apply the patch to the codebase directory
    success, message = git_apply_patch(
        patch_file_path, self.task_dir / "codebase", "dev"
    )
    ...
else:
    self._log(f"Failed to apply patch to codebase: {message}")    
    return False
```

The variable `message` is referenced, but it's only defined inside the `if patch_file_path:` block when `git_apply_patch()` is called. If `patch_file_path` is `False` or `None`, then the code tries to use message which is not defined in this scope, which would cause a `NameError: name 'message' is not defined` exception.