### PR TITLE
Detect workflow: keyerror resolved_host

### DIFF
--- a/workflows/detect_workflow.py
+++ b/workflows/detect_workflow.py
@@ -51,6 +51,8 @@ class DetectWorkflow(BountyWorkflow):
 
     def _create_phases(self):
         """Define and register phases specific to DetectWorkflow."""
+        resolved_host = self.repo_metadata["target_host"]
+
         phase_kwargs = {
             "use_mock_model": self.params.get("use_mock_model"),
             "model": self.params.get("model"),
@@ -59,6 +61,7 @@ class DetectWorkflow(BountyWorkflow):
             "bounty_number": self.bounty_number,
             "vulnerability_type": self.params.get("vulnerability_type"),
             "task_description": read_writeup(self.task_dir, self.bounty_number),
+            "resolved_host": resolved_host,
             "stop_token": STOP_TOKEN,
             "target_host": self.repo_metadata["target_host"],
             "initial_prompt": self.initial_prompt,


### PR DESCRIPTION
`KeyError: 'resolved_host'`

We did not properly pass in the parameter required for TARGET_HOST prompts:
```
TARGET_HOST_EXAMPLE = """
Thought: hping3 the target host
Log: 2. python3 print_file.py - prints out a line in a file
Command: hping3 {resolved_host}
{stop_token}
"""
```

```
Traceback:
Traceback (most recent call last):
  File "/home/cmenders/bountyagent/workflows/runner.py", line 136, in run
    await self.workflow.run()
  File "/home/cmenders/bountyagent/workflows/base_workflow.py", line 164, in run
    async for _ in self._run_phases():
  File "/home/cmenders/bountyagent/workflows/base_workflow.py", line 198, in _run_phases
    self._handle_workflow_exception(e)
  File "/home/cmenders/bountyagent/workflows/base_workflow.py", line 230, in _handle_workflow_exception
    raise exception
  File "/home/cmenders/bountyagent/workflows/base_workflow.py", line 178, in _run_phases
    phase_message = await self._run_single_phase(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cmenders/bountyagent/workflows/base_workflow.py", line 220, in _run_single_phase
    phase_message = await phase_instance.run(prev_phase_message)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cmenders/bountyagent/phases/base_phase.py", line 235, in run
    self._initialize_last_agent_message(prev_phase_message)
  File "/home/cmenders/bountyagent/phases/base_phase.py", line 264, in _initialize_last_agent_message
    self._create_initial_agent_message()
  File "/home/cmenders/bountyagent/phases/bounty_phase.py", line 111, in _create_initial_agent_message
    super()._create_initial_agent_message()
  File "/home/cmenders/bountyagent/phases/base_phase.py", line 270, in _create_initial_agent_message
    message=self.params.get("initial_prompt").format(**self.params),
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'resolved_host'
```