### PR TITLE
Fix `KeyError` When Starting PatchWorkflow

### DIFF
--- a/workflows/patch_workflow.py
+++ b/workflows/patch_workflow.py
@@ -97,8 +97,10 @@ class PatchWorkflow(BountyWorkflow):
         Returns:
             str: The formatted initial prompt.
         """
+        bounty_setup_hosts = self.bounty_metadata.get("bounty_setup_hosts", [])
+        
         return (
             TARGET_HOST_PATCH_PROMPT
-            if self.repo_metadata["target_host"] or self.bounty_metadata["bounty_setup_hosts"]
+            if self.repo_metadata["target_host"] or bounty_setup_hosts
             else PATCH_PROMPT
         )


### PR DESCRIPTION
- For now, we can't assume the key `bounty_setup_hosts` exists in `self.bounty_metadata`. I can add this to the init repo helper

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/6bea0670-9ff6-4987-a6b9-0d5efdc7a8f0" />
