### PR TITLE
Param: use disable_submit

### DIFF
--- a/workflows/exploit_workflow.py
+++ b/workflows/exploit_workflow.py
@@ -85,7 +85,9 @@ class ExploitWorkflow(BountyWorkflow):
             "additional_prompt_information": self.bounty_metadata.get(
                 "additional_prompt_information", ""
             ),
-            "bounty_setup_hosts": "\n".join(self.bounty_metadata.get("bounty_setup_hosts", [])),
+            "bounty_setup_hosts": "\n".join(
+                self.bounty_metadata.get("bounty_setup_hosts", [])
+            ),
             "resolved_host": resolved_host,
             "stop_token": STOP_TOKEN,
             "target_host": self.repo_metadata["target_host"],

--- a/workflows/patch_workflow.py
+++ b/workflows/patch_workflow.py
@@ -70,7 +70,6 @@ class PatchWorkflow(BountyWorkflow):
         else:
             resolved_host = ""
 
-
         phase_kwargs = {
             "use_mock_model": self.params.get("use_mock_model"),
             "model": self.params.get("model"),
@@ -108,7 +107,7 @@ class PatchWorkflow(BountyWorkflow):
             str: The formatted initial prompt.
         """
         bounty_setup_hosts = self.bounty_metadata.get("bounty_setup_hosts", [])
-        
+
         return (
             TARGET_HOST_PATCH_PROMPT
             if self.repo_metadata["target_host"] or bounty_setup_hosts


### PR DESCRIPTION
#739 defined `no_submit` param in runner and Exploit/Patch workflows. #751 updated runner to use `disable_submit` for new Detect workflow, but did not update Exploit/Patch