### PR TITLE
Detect phase summary

### DIFF
--- a/phases/detect_phase.py
+++ b/phases/detect_phase.py
@@ -166,14 +166,13 @@ class DetectPhase(BountyPhase):
 
         if isinstance(agent_instance, DetectAgent):
             if message.submission:
+                logger.status("Detect submitted!", message.success)
+                phase_message.set_summary("detect_submitted")
                 phase_message.set_complete()
             if message.success:
                 logger.status("Vulnerability detected!", True)
                 phase_message.set_summary("detect_success")
                 phase_message.set_success()
                 phase_message.set_complete()
-            else:
-                logger.status("Failed to detect vulnerability", False)
-                phase_message.set_summary("detect_failure")
 
         return message

--- a/phases/exploit_phase.py
+++ b/phases/exploit_phase.py
@@ -152,7 +152,7 @@ class ExploitPhase(BountyPhase):
 
         if isinstance(agent_instance, ExploitAgent):
             if message.submission:
-                logger.status("Exploit submitted!", True)
+                logger.status("Exploit submitted!", message.success)
                 phase_message.set_summary("exploit_submitted")
                 phase_message.set_complete()
             if message.success:

--- a/phases/patch_phase.py
+++ b/phases/patch_phase.py
@@ -151,7 +151,7 @@ class PatchPhase(BountyPhase):
 
         if isinstance(agent_instance, PatchAgent):
             if message.submission:
-                logger.info("Patch submitted!")
+                logger.info("Patch submitted!", message.success)
                 phase_message.set_summary("patch_submitted")
                 phase_message.set_complete()
             if message.success:


### PR DESCRIPTION
Detect/Exploit/Patch phase summaries should be consistent. 
Detect should not set:
```
phase_message.set_summary("detect_failure")
```
The summary should only be set once the workflow is complete, otherwise, the summary should stay `incomplete`