### PR TITLE
bump precommit version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
     -   id: black
         exclude: ^bountybench/
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
     -   id: isort
         exclude: ^bountybench/

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,9 @@ tenacity==9.0.0
 tiktoken==0.8.0
 uvicorn[standard]==0.34.0
 pre-commit==4.1.0
-black==24.10.0
+black==25.1.0
 flake8==7.1.1
-isort==5.13.2
+isort==6.0.1
 coverage==7.6.10
 pytest==7.4.4
 pytest-asyncio==0.23.6


### PR DESCRIPTION
### Description
- [x] **What does this PR do?**
- Updates precommit version used in pre-commit hook
- [x] **Why are these changes needed?/Changes made**
- The current version of isort (5.x.x) behaves differently than the CI (uses 6.x.x) causing some PRs to fail linting
- examples: https://github.com/cybench/bountyagent/actions/runs/14546237048
- https://github.com/cybench/bountyagent/actions/runs/14546075540
### Checklist (Review before submitting)
- [x] **Unit Tests:**
  - N/A
- [x] **Documentation:**
  - Will broadcast a slack message
- [x] **Peer Review:**
  - The PR must be reviewed by at least one team member before merging.

### Linked Issues
- Resolves #[issue-number]

### Additional Notes
Add any additional context, screenshots, or details that may assist the reviewer.
