### PR TITLE
Revert "bump precommit version"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 24.10.0
     hooks:
     -   id: black
         exclude: ^bountybench/
 
 -   repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+    rev: 5.13.2
     hooks:
     -   id: isort
         exclude: ^bountybench/

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,9 @@ tenacity==9.0.0
 tiktoken==0.8.0
 uvicorn[standard]==0.34.0
 pre-commit==4.1.0
-black==25.1.0
+black==24.10.0
 flake8==7.1.1
-isort==6.0.1
+isort==5.13.2
 coverage==7.6.10
 pytest==7.4.4
 pytest-asyncio==0.23.6


### PR DESCRIPTION
This isn't the right approach - we don't want to ask people to reinstall requirements.txt, update pre-commit, and then re-lint every file. CI should use the version defined in requirements.txt