### PR TITLE
update ci to use fixed version of precommit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Lint modified Python files
         run: |
           python -m pip install --upgrade pip
-          pip install black isort
+          pip install "black==24.10.0" "isort==5.13.2"
           # Simplified grep pattern to avoid parsing issues
           MODIFIED_PY_FILES=$(git diff --name-only --diff-filter=d origin/main HEAD | grep ".py$" | grep -v "^bountybench/" || echo "")
           if [ -n "$MODIFIED_PY_FILES" ]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,11 @@ tenacity==9.0.0
 tiktoken==0.8.0
 uvicorn[standard]==0.34.0
 pre-commit==4.1.0
-black==25.1.0
+# NOTE: The versions of black and isort are hardcoded here.
+# If you change them, you must also update .pre-commit-config.yaml and .github/workflows/ci.yml.
+black==24.10.0
 flake8==7.1.1
-isort==6.0.1
+isort==5.13.2
 coverage==7.6.10
 pytest==7.4.4
 pytest-asyncio==0.23.6


### PR DESCRIPTION
reverts https://github.com/cybench/bountyagent/pull/871 and fixes version of precommit used in CI