### PR TITLE
log raw llm response

### DIFF
--- a/resources/model_resource/model_resource.py
+++ b/resources/model_resource/model_resource.py
@@ -245,6 +245,7 @@ class ModelResource(RunnableBaseResource):
                 exception=e,
                 input=model_input,
             ) from e
+        logger.info(f"Original unedited response: {model_response}")
 
         lm_response = self.remove_hallucinations(model_response.content)
         lm_response = self.remove_stop_token(lm_response)


### PR DESCRIPTION
Logging the raw llm response to stdout before we run post-processing. 

There is an open design question on whether we should display the raw response to the frontend UI.

At the very least, having some records of raw responses will be a significant improvement