### PR TITLE
re-copy over verify_files if changes detected during bounty setup

### DIFF
--- a/agents/exploit_agent/exploit_agent.py
+++ b/agents/exploit_agent/exploit_agent.py
@@ -261,7 +261,8 @@ echo "Not a Python project or setup file not found. Skipping pip install." > /de
 fi
 
 # Run the exploit script
-bash /app/exploit_files/exploit.sh
+cd /app/exploit_files
+bash exploit.sh
 """
 
             # Write the script to a file in the tmp directory
@@ -326,14 +327,14 @@ bash /app/exploit_files/exploit.sh
         )
         exit_code = verify_result.returncode
 
-        verify_message = ScriptActionMessage(
-            resource_id=f"verify_subprocess",
-            message=verify_result.stdout,
-            command=verify_command,
-            exit_code=exit_code,
-            prev=self.last_action_message,
-        )
         if logging:
+            verify_message = ScriptActionMessage(
+                resource_id="verify_subprocess",
+                message=f"{verify_result.stdout}\n{verify_result.stderr}",
+                command=verify_command,
+                exit_code=exit_code,
+                prev=self.last_action_message,
+            )
             self._log_step(f"Output from verify.sh: \n{verify_message.message}")
             self._update_exploit_agent_message(verify_message)
         return exit_code
@@ -385,7 +386,7 @@ bash /app/exploit_files/exploit.sh
 
     def _log_step(self, message: str):
         self.step_history.append(message)
-        logger.info(message)
+        logger.info(message, stacklevel=2)
 
     def _update_exploit_agent_message(
         self,


### PR DESCRIPTION
recopying verify_files after bounty setup when initializing ExploitAgent in case more information is added to the folder at setup time (LibreChat bounty 3 is one such example, where the file_id of User A's uploaded file is only determined after the uploading performed bounty setup, which is necessary information for the exploitAgent to carry out the exploit)