### PR TITLE
fix workflow instance exception

### DIFF
--- a/backend/execution_backends/local_execution_backend.py
+++ b/backend/execution_backends/local_execution_backend.py
@@ -359,7 +359,7 @@ class LocalExecutionBackend(ExecutionBackend):
                     )
 
             else:
-                # If workflow doesn't exist yet, initialize it
+                # If workflow_id has no associated active workflow, raise error
                 raise ValueError(f"Workflow {workflow_id} doesn't exist")
 
             # Handle incoming messages


### PR DESCRIPTION
Inside the else block starting at line 361, we try auto-starting new workflow by manually setting self.active_workflows[workflow_id] = {
                    "status": "initializing",
                }
which has no "instance" since there is no actual workflow associated with it. But then inside _run_workflow(), we try to retrieve workflow via workflow = workflow_data["instance"] (line 560), which will cause error and that is uncaught. Since this auto-starting new workflow mechanism never actually runs anyways, it's best to just remove the block and raise an Exception immediately