### PR TITLE
[wip - investigation] Docker container permissions vs host machine

### DIFF
--- a/resources/docker_resource.py
+++ b/resources/docker_resource.py
@@ -1,5 +1,6 @@
 import atexit
 import json
+import os
 import threading
 import time
 import uuid
@@ -102,6 +103,9 @@ class DockerResource(RunnableBaseResource):
         Returns:
             tuple: A tuple containing the logs from the container and the exit code.
         """
+        uid = os.getuid()
+        gid = os.getgid()
+        user_param = f"{uid}:{gid}"
 
         unique_name = f"{self.resource_id}-{uuid.uuid4().hex[:10]}"
 
@@ -125,6 +129,7 @@ class DockerResource(RunnableBaseResource):
                 network=network,
                 working_dir=work_dir,
                 detach=True,
+                user=user_param,
                 name=unique_name,
             )
 

--- a/resources/kali_env_resource.py
+++ b/resources/kali_env_resource.py
@@ -348,6 +348,10 @@ class KaliEnvResource(RunnableBaseResource):
     def _create_and_start_container(
         self, name: str, volumes: Optional[Dict[str, Dict[str, str]]], attempt: int
     ) -> Optional[Container]:
+        uid = os.getuid()
+        gid = os.getgid()
+        user_param = f"{uid}:{gid}"
+
         start_progress(
             f"Starting a new Docker container (Attempt {attempt + 1}/{MAX_RETRIES})..."
         )
@@ -370,6 +374,7 @@ class KaliEnvResource(RunnableBaseResource):
                 cgroupns="host",
                 network="shared_net",
                 volumes=volumes,
+                user=user_param,
                 entrypoint=ENTRYPOINT,
                 privileged=True,
                 detach=True,


### PR DESCRIPTION
I was seeing cleanup failures in runs for getting rid of created files, e.g. in ExploitWorkflow zipp 0:
```
warning: failed to remove zipp.egg-info/requires.txt: Permission denied
warning: failed to remove zipp.egg-info/SOURCES.txt: Permission denied
warning: failed to remove zipp.egg-info/PKG-INFO: Permission denied
warning: failed to remove zipp.egg-info/top_level.txt: Permission denied
warning: failed to remove zipp.egg-info/dependency_links.txt: Permission denied
warning: failed to remove zipp/__pycache__/glob.cpython-39.pyc: Permission denied
warning: failed to remove zipp/__pycache__/__init__.cpython-39.pyc: Permission denied
warning: failed to remove zipp/compat/__pycache__/py310.cpython-39.pyc: Permission denied
warning: failed to remove zipp/compat/__pycache__/__init__.cpython-39.pyc: Permission denied
2025-04-17 21:49:14 WARNING  [utils/git_utils.py:36]
Git command failed: git clean -fd - Command '['git', 'clean', '-fd']' returned non-zero exit status 1.
```
Side effect files from runs (created during script execution in `KaliEnvResource` or `DockerResource` seem to have elevated permissions.
The key issue here is that files created within the Docker containers during the exploit/other execution end up having permissions that don't allow them to be removed by the `git clean` command that runs outside the Docker container on the host machine. 

The Docker container is running as root, which is potentially different than the process running outside Docker. This is an issue we see when running locally, (but less so when running in dockerized backend because backend container also runs with root).

This is a common problem with Docker volume mounts - files created inside the container by the container user can't be modified by the host user because of permission differences. This is causing runs to fail in the cleanup stage, but also feels problematic that our host machine, which we are treating as the more 'privileged' environment (e.g. running `verify.sh` here), may actually have lower permissions.
Example permissions on files created in agent env vs local env:
![image](https://github.com/user-attachments/assets/64c72c7e-5e4e-49c1-a25e-6c94656f137c)
(agent can delete `host_created` file, host cannot delete `agent_created` file)

I propose the follow change:
The Docker containers should be started with permissions matching that of the host machine. This way, the permissions will never be elevated past what the host can do.