### PR TITLE
PatchPhase: use status for logging

### DIFF
--- a/phases/patch_phase.py
+++ b/phases/patch_phase.py
@@ -151,7 +151,7 @@ class PatchPhase(BountyPhase):
 
         if isinstance(agent_instance, PatchAgent):
             if message.submission:
-                logger.info("Patch submitted!", message.success)
+                logger.status("Patch submitted!", message.success)
                 phase_message.set_summary("patch_submitted")
                 phase_message.set_complete()
             if message.success:


### PR DESCRIPTION
Should be using `logger.status` not `logger.info` otherwise will get the issue:
```
Traceback (most recent call last):
  File "/usr/lib/python3.11/logging/handlers.py", line 1492, in emit
    self.enqueue(self.prepare(record))
                 ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/handlers.py", line 1474, in prepare
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 953, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 687, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
    self._context.run(self._callback, *self._args)
  File "/home/cmenders/bountyagent/workflows/runner.py", line 258, in main
    return await runner.run()
  File "/home/cmenders/bountyagent/workflows/runner.py", line 136, in run
    await self.workflow.run()
  File "/home/cmenders/bountyagent/workflows/base_workflow.py", line 164, in run
    async for _ in self._run_phases():
  File "/home/cmenders/bountyagent/workflows/base_workflow.py", line 178, in _run_phases
    phase_message = await self._run_single_phase(
  File "/home/cmenders/bountyagent/workflows/base_workflow.py", line 220, in _run_single_phase
    phase_message = await phase_instance.run(prev_phase_message)
  File "/home/cmenders/bountyagent/phases/base_phase.py", line 246, in run
    await self._run_iteration()
  File "/home/cmenders/bountyagent/phases/base_phase.py", line 296, in _run_iteration
    agent_message: AgentMessage = await self.run_one_iteration(
  File "/home/cmenders/bountyagent/phases/patch_phase.py", line 154, in run_one_iteration
    logger.info("Patch submitted!", message.success)
Message: 'Patch submitted!'
Arguments: (False,)
```