### PR TITLE
Avoid creating `ScriptActionMessage` if logging is false

### DIFF
--- a/agents/exploit_agent/exploit_agent.py
+++ b/agents/exploit_agent/exploit_agent.py
@@ -319,14 +319,14 @@ bash /app/exploit_files/exploit.sh
         )
         exit_code = verify_result.returncode
 
-        verify_message = ScriptActionMessage(
-            resource_id=f"verify_subprocess",
-            message=f"{verify_result.stdout}\n{verify_result.stderr}",
-            command=verify_command,
-            exit_code=exit_code,
-            prev=self.last_action_message,
-        )
         if logging:
+            verify_message = ScriptActionMessage(
+                resource_id="verify_subprocess",
+                message=f"{verify_result.stdout}\n{verify_result.stderr}",
+                command=verify_command,
+                exit_code=exit_code,
+                prev=self.last_action_message,
+            )
             self._log_step(f"Output from verify.sh: \n{verify_message.message}")
             self._update_exploit_agent_message(verify_message)
         return exit_code


### PR DESCRIPTION
This will fix showing wrong action messages on the frontend