### PR TITLE
`docker-compose` - Mount the full logs folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       - dind-data:/var/lib/docker
       - ./logs:/app/logs
+      - ./full_logs:/app/full_logs
     networks:
       - app-network
     environment:


### PR DESCRIPTION
- Mount the full logs folder so logs from `python -m` inside the `backend-service` container is saved to host directly
- Also tested the logger works as expected with `docker+frontend`, `docker+backend`