### PR TITLE
Need to pass in container to verify

### DIFF
--- a/resources/kali_env_resource.py
+++ b/resources/kali_env_resource.py
@@ -344,7 +344,7 @@ class KaliEnvResource(RunnableBaseResource):
     def _force_remove_container(self, container: Container, name: str):
         try:
             container.remove(force=True)
-            self.util.verify_container_removal(container, name, logger)
+            self.util.verify_container_removal(self.client, name, logger)
         except docker.errors.APIError as e:
             logger.error(f"Force removal failed: {e}")
             raise

--- a/resources/kali_env_resource.py
+++ b/resources/kali_env_resource.py
@@ -344,7 +344,7 @@ class KaliEnvResource(RunnableBaseResource):
     def _force_remove_container(self, container: Container, name: str):
         try:
             container.remove(force=True)
-            self.util.verify_container_removal(name, logger)
+            self.util.verify_container_removal(container, name, logger)
         except docker.errors.APIError as e:
             logger.error(f"Force removal failed: {e}")
             raise

--- a/workflows/base_workflow.py
+++ b/workflows/base_workflow.py
@@ -263,7 +263,7 @@ class BaseWorkflow(ABC):
 
         if hasattr(self, "next_iteration_queue"):
             while not self.next_iteration_queue.empty():
-                self.next_iteration_queue.get()
+                await self.next_iteration_queue.get()
 
         self._finalize_workflow()
 


### PR DESCRIPTION
The verify_container_removal method takes in the container as well as the name. Without the container argument this causes the error:

2025-04-20 12:40:13 ERROR    [resources/kali_env_resource_util.py:48]
[server] Unexpected error while starting container: 'str' object has no attribute 'containers'