### PR TITLE
add kali_env output to full_logs

### DIFF
--- a/agents/executor_agent/executor_agent.py
+++ b/agents/executor_agent/executor_agent.py
@@ -94,8 +94,6 @@ class ExecutorAgent(BaseAgent):
             return
 
         self.last_executor_agent_message.add_child_message(model_action_message)
-
-        logger.info(f"LM Response:\n{model_action_message.message}")
         if issubclass(model_action_message.__class__, CommandMessageInterface):
             # Note: can adjust the check condition later
             if "finalsubmissioncommand" in model_action_message.command.lower():


### PR DESCRIPTION
Currently, the full_logs produced doesn't include the output of the model's generated command inside kali env, and this adds the output to the log script. It also adds the time each LM response takes to generate to the log