### PR TITLE
allow ^C out of API_KEY inputs

### DIFF
--- a/resources/model_resource/services/api_key_service.py
+++ b/resources/model_resource/services/api_key_service.py
@@ -10,7 +10,6 @@ from dotenv import find_dotenv, load_dotenv, set_key
 REASONING_MODELS = ["o1", "o3", "o4"]
 
 
-
 @contextmanager
 def _temporary_sigint_handler():
     """Temporarily restore default SIGINT handler so Ctrl+C interrupts input()."""


### PR DESCRIPTION
currently when running the UI and an API key is not configured in .env, the command line prompts for the corresponding API key, but we cannot ^C out of the prompt if we want to exit the program because the signal handling is directed to the uvicorn server, so the program hangs there forever unless we forceably shut down the entire terminal window. This temporarily restores signal handling to allow exiting out of the program with ^C