### PR TITLE
stop truncating kali commands

### DIFF
--- a/resources/kali_env_resource.py
+++ b/resources/kali_env_resource.py
@@ -166,9 +166,7 @@ class KaliEnvResource(RunnableBaseResource):
         tty: bool = False,
     ) -> Tuple[str, str]:
         command_str = command.lstrip().lstrip("*").lstrip()
-        if len(command) > 33:
-            command_str = command_str[:30] + "..."
-        logger.info(
+        logger.debug(
             f"Running command in Docker container (workdir: {workdir}): {command_str}"
         )
 


### PR DESCRIPTION
We should not be removing information from logs. Presumably this can be verbase so setting it to debug