### PR TITLE
Add Scripts to Support Git Usage in Container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - dind-data:/var/lib/docker
       - ./logs:/app/logs
       - ./full_logs:/app/full_logs
+      - ${HOME}/.ssh/id_rsa_backend-service:/root/.ssh/id_rsa:ro
+      - ${HOME}/.ssh/id_rsa_backend-service.pub:/root/.ssh/id_rsa.pub:ro
     networks:
       - app-network
     environment:

--- a/tools/dockerd-entrypoint.sh
+++ b/tools/dockerd-entrypoint.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+# SSH Key Setup
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+if [ -f /root/.ssh/id_rsa ]; then
+  chmod 600 /root/.ssh/id_rsa
+  eval "$(ssh-agent -s)"
+  ssh-add /root/.ssh/id_rsa
+  echo "[entrypoint] SSH key loaded."
+else
+  echo "[entrypoint] No SSH key at /root/.ssh/id_rsa – skipping."
+fi
+
 # Function to check if Docker daemon is already running
 check_dockerd() {
     # Use 'docker info' to check if the daemon is responsive

--- a/tools/ssh_key_gen.sh
+++ b/tools/ssh_key_gen.sh
@@ -1,0 +1,7 @@
+ssh-keygen -t rsa -b 4096 \
+  -f ~/.ssh/id_rsa_backend-service \
+  -C "backend-service key" \
+  -N "" && \
+eval "$(ssh-agent -s)" && \
+ssh-add ~/.ssh/id_rsa_backend-service && \
+cat ~/.ssh/id_rsa_backend-service.pub


### PR DESCRIPTION
- Run `chmod +x tools/ssh_key_gen.sh && tools/ssh_key_gen.sh` to create the `id_rsa_backend-service` key pair
- Mount the keys in `docker-compose.yml`. These two lines can be safely removed/changed without needing to rebuild the container (only mounting)
- Modify `dockerd-entrypoint.sh` to automatically load keys to ssh agent

Demo: rebuild container -> git works out of the box
<img width="1235" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/08cc72e9-859f-47ca-966e-b648052a8eb2" />
