### PR TITLE
[dev] Add `experiment_config` script / template

### DIFF
--- a/k8s/experiment-config/experiment_config_parser.py
+++ b/k8s/experiment-config/experiment_config_parser.py
@@ -1,0 +1,63 @@
+import json
+import argparse
+import sys
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate runner.py commands from config JSON")
+    parser.add_argument('--config', required=True, help='Path to JSON config file')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    try:
+        with open(args.config, 'r') as f:
+            cfg = json.load(f)
+    except Exception as e:
+        print(f"Failed to load config: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    required = ['workflow_type', 'phase_iterations', 'use_helm', 'model', 'max_input_tokens', 'max_output_tokens', 'tasks']
+    for k in required:
+        if k not in cfg:
+            print(f"Missing key '{k}' in config", file=sys.stderr)
+            sys.exit(1)
+
+    workflow = cfg['workflow_type']
+    phase_iter = cfg['phase_iterations']
+    use_helm = cfg['use_helm']
+    model = cfg['model']
+    max_in = cfg['max_input_tokens']
+    max_out = cfg['max_output_tokens']
+    tasks = cfg['tasks']
+
+    commands = []
+    for entry in tasks:
+        if '/' in entry:
+            task_dir, bounty = entry.split('/', 1)
+            # prefix with bountybench
+            task_dir = f"bountybench/{task_dir}"
+        else:
+            print(f"Invalid task entry '{entry}', expected 'task_dir/bounty_number'", file=sys.stderr)
+            sys.exit(1)
+        parts = [
+            'python', '-m', 'workflows.runner',
+            '--workflow-type', workflow,
+            '--phase_iterations', str(phase_iter),
+        ]
+        if use_helm:
+            parts.append('--use_helm')
+        parts.extend([
+            '--model', model,
+            '--max_input_tokens', str(max_in),
+            '--max_output_tokens', str(max_out),
+            '--task_dir', task_dir,
+            '--bounty_number', bounty
+        ])
+        commands.append(' '.join(parts))
+
+    for cmd in commands:
+        print(cmd)
+
+if __name__ == '__main__':  # noqa: C901
+    main()

--- a/k8s/experiment-config/experiment_config_template.json
+++ b/k8s/experiment-config/experiment_config_template.json
@@ -1,0 +1,12 @@
+{
+  "workflow_type": "<workflow_type>",
+  "phase_iterations": <phase_iterations>,
+  "use_helm": <true_or_false>,
+  "model": "<model_name>",
+  "max_input_tokens": <max_input_tokens>,
+  "max_output_tokens": <max_output_tokens>,
+  "tasks": [
+    "<task_dir_1>/<bounty_number_1>",
+    "<task_dir_2>/<bounty_number_2>"
+  ]
+}


### PR DESCRIPTION
For running experiments at scale on GKE, this is my current plan:
1) We should have a list of bounties ready (manually tested + verified bounties)
2) We can split the bounties into different experiment groups (probably 5 groups with 5 bounties in each group) such that we can avoid 1) bounties beloning to the same repo will not be in the same group 2) there won't be any port conflicts 3) Can ensure we use a resaonble amount of storage for each pod + speed is fast
3) Use StatefulSet to deploy pods on GKE cluster (and we can set up multiple clusters if needed) and each pod is responsible for one experiment group

In this way, we can make sure that 1) each pod only need to initialize ~5 bounty repos which can save disk space 2) each pod can run their bounties in parallel to ensure speed 3) experiment config is uniform across the bounties and is easy to update for different workflows / models 4) no need to repull docker image every time which saves time.

(Note: the only issue with this approach is that we might not able to get the correct full log for each run. However, I think when we run things at scale, the full log might not be needed as it's mainly for debugging)