### PR TITLE
Track if invoked from command line in workflows

### DIFF
--- a/phases/base_phase.py
+++ b/phases/base_phase.py
@@ -27,6 +27,7 @@ class PhaseConfig:
     agent_configs: List[Tuple[str, "AgentConfig"]] = field(default_factory=list)
     max_iterations: int = field(default=10)
     interactive: bool = False
+    command_line: bool = False
     phase_idx: Optional[int] = None
 
     @classmethod
@@ -49,7 +50,6 @@ class BasePhase(ABC):
         self.workflow: "BaseWorkflow" = workflow
         self.workflow_id = workflow.workflow_message.workflow_id
         self.phase_config: PhaseConfig = PhaseConfig.from_phase(self, **kwargs)
-
         self.agent_manager: Any = self.workflow.agent_manager
         self.resource_manager: Any = self.workflow.resource_manager
         self.agents: List[Tuple[str, BaseAgent]] = []
@@ -285,7 +285,9 @@ class BasePhase(ABC):
     async def _handle_interactive_mode(self) -> None:
         """Handle the interactive mode if enabled."""
         if self.phase_config.interactive:
-            if hasattr(self.workflow, "next_iteration_queue"):
+            if self.phase_config.command_line:
+                input("Press Enter to continue...")
+            elif hasattr(self.workflow, "next_iteration_queue"):
                 logger.info("Waiting for 'next' signal ...")
                 await self.workflow.next_iteration_queue.get()
             else:

--- a/workflows/base_workflow.py
+++ b/workflows/base_workflow.py
@@ -35,6 +35,7 @@ class BaseWorkflow(ABC):
         self.params = kwargs
         # Required for interactive controller
         self.interactive = kwargs.get("interactive", False)
+        self.command_line = kwargs.get("command_line", False)
         self._current_phase_idx = 0
         self._phase_graph = {}  # Stores phase relationships
         self._root_phase = None

--- a/workflows/detect_workflow.py
+++ b/workflows/detect_workflow.py
@@ -78,6 +78,7 @@ class DetectWorkflow(BountyWorkflow):
             "max_input_tokens": self.params.get("max_input_tokens"),
             "max_output_tokens": self.params.get("max_output_tokens"),
             "interactive": self.interactive,
+            "command_line": self.command_line,
             "max_iterations": self.params.get("phase_iterations"),
             "submit": not self.params.get("disable_submit", False),
         }

--- a/workflows/exploit_patch_workflow.py
+++ b/workflows/exploit_patch_workflow.py
@@ -86,6 +86,7 @@ class ExploitPatchWorkflow(BountyWorkflow):
             "max_input_tokens": self.params.get("max_input_tokens"),
             "max_output_tokens": self.params.get("max_output_tokens"),
             "interactive": self.interactive,
+            "command_line": self.command_line,
             "max_iterations": self.params.get("phase_iterations"),
         }
 

--- a/workflows/exploit_workflow.py
+++ b/workflows/exploit_workflow.py
@@ -89,6 +89,7 @@ class ExploitWorkflow(BountyWorkflow):
             "max_input_tokens": self.params.get("max_input_tokens"),
             "max_output_tokens": self.params.get("max_output_tokens"),
             "interactive": self.interactive,
+            "command_line": self.command_line,
             "max_iterations": self.params.get("phase_iterations"),
             "submit": not self.params.get("disable_submit", False),
         }

--- a/workflows/patch_workflow.py
+++ b/workflows/patch_workflow.py
@@ -84,6 +84,7 @@ class PatchWorkflow(BountyWorkflow):
             "max_input_tokens": self.params.get("max_input_tokens"),
             "max_output_tokens": self.params.get("max_output_tokens"),
             "interactive": self.interactive,
+            "command_line": self.command_line,
             "max_iterations": self.params.get("phase_iterations"),
             "submit": not self.params.get("disable_submit", False),
         }

--- a/workflows/runner.py
+++ b/workflows/runner.py
@@ -144,6 +144,8 @@ class WorkflowRunner:
         # Remove None values from kwargs
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
 
+        kwargs["command_line"] = True
+
         # Handle path conversions
         for arg in ["task_dir", "log_dir"]:
             if arg in kwargs and kwargs[arg] is not None:


### PR DESCRIPTION
### Problem
Right now if the workflows are run from the command line and there is an error, there is a message showing "Waiting for 'next' signal". This expects a signal is sent to the next_iteration_queue, however this is linked to UI. In command line, there should be a way to continue the iteration for transient errors.

### Solution
If run from cmd, instead of the next signal, we will just wait for an [ENTER] keystroke from the user.

### Description
- [x] **What does this PR do?**
- [ ] **Why are these changes needed?/Changes made**

### Checklist (Review before submitting)
- [ ] **Unit Tests:**
  - Include test cases for new code or functionality.
  - Ensure all tests pass by running the test suite.
- [ ] **Documentation:**
  - Add or update inline comments where applicable.
  - Update any relevant README or documentation files.
- [ ] **Peer Review:**
  - The PR must be reviewed by at least one team member before merging.

### Linked Issues
- Resolves #770 

### Additional Notes
Add any additional context, screenshots, or details that may assist the reviewer.
