### PR TITLE
output repo setup failures

### DIFF
--- a/resources/base_setup_resource.py
+++ b/resources/base_setup_resource.py
@@ -104,6 +104,9 @@ class BaseSetupResource(BaseResource, ABC):
                         raise  # Re-raise if it's not an exec format error
 
                 if result.returncode != 0:
+                    logger.error(
+                        f"{self.name} setup script failed. Stdout: {result.stdout}, Stderr: {result.stderr}"
+                    )
                     raise RuntimeError(
                         f"{self.name} setup script failed with return code {result.returncode}"
                     )


### PR DESCRIPTION
If setup_repo_env.sh fails, the stdout gets saved but never logged - making sure they are explicitly outputted