### PR TITLE
fix model service

### DIFF
--- a/resources/model_resource/model_mapping.py
+++ b/resources/model_resource/model_mapping.py
@@ -284,11 +284,11 @@ class NonHelmMapping:
         # ------------------------
         # Together Models (DeepSeek)
         # ------------------------
-        "deepseek-ai/deepseek-v3": NonHelmModelInfo(
-            model_name="deepseek-ai/deepseek-v3", provider=ServiceProvider.TOGETHER
+        "deepseek-ai/deepSeek-V3": NonHelmModelInfo(
+            model_name="deepseek-ai/DeepSeek-V3", provider=ServiceProvider.TOGETHER
         ),
-        "deepseek-ai/deepseek-r1": NonHelmModelInfo(
-            model_name="deepseek-ai/deepseek-r1", provider=ServiceProvider.TOGETHER
+        "deepseek-ai/DeepSeek-R1": NonHelmModelInfo(
+            model_name="deepseek-ai/DeepSeek-R1", provider=ServiceProvider.TOGETHER
         ),
         # ------------------------
         # Mistral Models

--- a/resources/model_resource/services/auth_helpers.py
+++ b/resources/model_resource/services/auth_helpers.py
@@ -121,7 +121,7 @@ def _auth_anthropic_api_key(
     return False, response.text
 
 
-def _auth_google_gemini_api_key(
+def _auth_google_api_key(
     api_key: str, model_name: str = None, verify_model: bool = False
 ) -> Tuple[bool, str]:
     url = "https://generativelanguage.googleapis.com/v1/models"

--- a/resources/model_resource/services/service_providers.py
+++ b/resources/model_resource/services/service_providers.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 from resources.model_resource.services.auth_helpers import (
     _auth_anthropic_api_key,
-    _auth_google_gemini_api_key,
+    _auth_google_api_key,
     _auth_helm_api_key,
     _auth_openai_api_key,
     _auth_together_api_key,
@@ -41,8 +41,8 @@ PROVIDER_CONFIG: dict[ServiceProvider, ServiceProviderConfig] = {
     ),
     ServiceProvider.GOOGLE: ServiceProviderConfig(
         name="google",
-        api_key_name="GOOGLE_GEMINI_API_KEY",
-        auth_function=_auth_google_gemini_api_key,
+        api_key_name="GOOGLE_API_KEY",
+        auth_function=_auth_google_api_key,
     ),
     ServiceProvider.TOGETHER: ServiceProviderConfig(
         name="together",


### PR DESCRIPTION
We inadvertantly changed GOOGLE_API_KEY to GOOGLE_GEMINI_API_KEY - reverting.

Additionally, HELM name for Deepseek is inconsistent with the together API - updating our code accordingly