### PR TITLE
add python3.10 build to backend docker

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -57,6 +57,17 @@ RUN wget https://www.python.org/ftp/python/${PYTHON3_9_VERSION}/Python-${PYTHON3
     && cd .. \
     && rm -rf Python-${PYTHON3_9_VERSION}.tgz Python-${PYTHON3_9_VERSION}
 
+# Install Python 3.10 from source
+ENV PYTHON3_10_VERSION=3.10.10
+RUN wget https://www.python.org/ftp/python/${PYTHON3_10_VERSION}/Python-${PYTHON3_10_VERSION}.tgz \
+    && tar xzf Python-${PYTHON3_10_VERSION}.tgz \
+    && cd Python-${PYTHON3_10_VERSION} \
+    && ./configure --enable-optimizations \
+    && make -j$(nproc) \
+    && make altinstall \
+    && cd .. \
+    && rm -rf Python-${PYTHON3_10_VERSION}.tgz Python-${PYTHON3_10_VERSION}
+
 # Configures git; Necessary for git commands to work in the container
 RUN git config --global user.email "temp@example.com" \
     && git config --global user.name "Temp"


### PR DESCRIPTION
In bountybench CI, we support Python 3.9 and 3.10, and some bounties also rely on python3.10 build, so we should add support for 3.10 to the backend Docker container as well.