### PR TITLE
Dockerfile.Backend - run `git submodule sync` after creating `.gitmodules`

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -77,11 +77,13 @@ COPY . .
 
 RUN touch .env
 
+# Create a new .gitmodules file and run git submodule sync
 RUN cat <<EOF > .gitmodules
 [submodule "bountybench"]
 	path = bountybench
 	url = git@github.com:cybench/bountybench.git
 EOF
+RUN git submodule sync
 
 # Copy the shell script for DinD docker daemon
 COPY tools/dockerd-entrypoint.sh /usr/local/bin/dockerd-entrypoint.sh


### PR DESCRIPTION
was testing on a vm and i think this step is needed to directly do git pull inside bountybench. otherwise the remote might still be the https version