### PR TITLE
Fix issue where no log is displayed in `LogViewer`

### DIFF
--- a/backend/routers/logs.py
+++ b/backend/routers/logs.py
@@ -92,6 +92,9 @@ async def get_log(filename: str):
         / model
         / filename
     )
+    alt_file_path = LOG_DIR / filename
+    if alt_file_path.exists():
+        file_path = alt_file_path
     if not file_path.exists() or not file_path.suffix == ".json":
         raise HTTPException(status_code=404, detail="Log file not found")
     try:


### PR DESCRIPTION
- The backend endpoint should use `rglob` to recursively collect `*.json` files with the new directory structure
- Updated the get log endpoint to reconstruct the correct path

<img width="1542" alt="image" src="https://github.com/user-attachments/assets/716c4f45-fc53-41a4-a585-21f571e22e24" />
