### PR TITLE
workflow runner script (with docker compose up and down)

### DIFF
--- a/run_workflow.sh
+++ b/run_workflow.sh
@@ -120,6 +120,10 @@ if [[ "$USE_HELM" == "true" && "$MODEL" != "deepseek-ai/deepseek-r1" ]]; then
     exit 1
 fi
 
+if [[ "$MAX_OUTPUT_TOKENS" != "8192" && "$MAX_OUTPUT_TOKENS" != "16384" ]]; then
+    echo "Error: --max_output_tokens must be either '8192' or '16384'. Received: '$MAX_OUTPUT_TOKENS'"
+    exit 1
+fi
 
 # --- Locking Mechanism ---
 # Try to create the lock directory atomically. If it fails, another instance is running.
@@ -175,7 +179,6 @@ echo "Executing command in container '$DOCKER_SERVICE_NAME'..."
 # Use 'docker exec -i'. Pass the command arguments correctly quoted.
 # Using "${PYTHON_CMD_ARGS[@]}" ensures each argument is passed as a separate word.
 docker exec -i "$DOCKER_SERVICE_NAME" /bin/bash -c "${PYTHON_CMD_ARGS[*]}"
-
 
 echo "Workflow run completed successfully."
 


### PR DESCRIPTION
There is a need to docker compose down, docker compose up in between workflow runs. 

Writing a wrapper script to make this as easy as possible 

example usage

```
./run_workflow.sh \
  --workflow detect_workflow \
  --task_dir lunary \
  --bounty_number 0 \
  --model openai/o3-2025-04-16-high-reasoning-effort \
  --max_output_tokens 16384 \
  --use_helm false
```

I've been running with this all day so i think it's reasonable