### PR TITLE
Add bountybench commit to log

### DIFF
--- a/messages/workflow_message.py
+++ b/messages/workflow_message.py
@@ -54,6 +54,7 @@ class WorkflowMessage(Message):
         message_dict[self.workflow_id][self.workflow_id] = self
 
         self._codebase_version = git_get_codebase_version()
+        self._task_codebase_version = None
 
         # Logging
         self.logs_dir = Path(logs_dir)
@@ -67,6 +68,13 @@ class WorkflowMessage(Message):
                         str(value.name if isinstance(value, Path) else value)
                     )
         self._task_components = "_".join(components)  # e.g. lunary_0
+
+        if task:
+            task_dir = task.get("task_dir")
+            if task_dir:
+                task_dir_root = task_dir.split("/")[0]
+                task_codebase = Path(task_dir_root)
+                self._task_codebase_version = git_get_codebase_version(task_codebase)
 
         self.set_full_log_dir_path()
         logger.debug(f"Creating new log file in directory: {self._full_log_dir_path}")
@@ -101,6 +109,10 @@ class WorkflowMessage(Message):
     @property
     def codebase_version(self) -> str:
         return self._codebase_version
+
+    @property
+    def task_codebase_version(self) -> str:
+        return self._task_codebase_version
 
     @property
     def iterations_taken(self) -> int:
@@ -183,6 +195,7 @@ class WorkflowMessage(Message):
             "workflow_id": self.workflow_id,
             "additional_metadata": self.additional_metadata,
             "codebase_version": self.codebase_version,
+            "task_codebase_version": self.task_codebase_version,
         }
 
     def save(self):

--- a/utils/git_utils.py
+++ b/utils/git_utils.py
@@ -603,9 +603,10 @@ def git_get_current_commit(directory_path: PathLike) -> Optional[str]:
         return None
 
 
-def git_get_codebase_version() -> Optional[str]:
+def git_get_codebase_version(directory: Optional[Path] = None) -> Optional[str]:
     """Get the current git commit short hash as a version identifier."""
-    directory = Path.cwd()
+    if not directory:
+        directory = Path.cwd()
 
     # Validate git repository
     if not (directory / ".git").exists():


### PR DESCRIPTION
We are currently unable to track what version bountybench is at time of run. There are various scripts, e.g. invariants, healthchecks that we are currently changing but no way to track version, leaving us vulnerable to failures (due to script changes), with no good way to triage. Now, we add bountybench commit (same as bountyagent commit) to workflow log