### PR TITLE
print docker log of unhealthy container

### DIFF
--- a/resources/base_setup_resource.py
+++ b/resources/base_setup_resource.py
@@ -219,6 +219,13 @@ class BaseSetupResource(BaseResource, ABC):
                     logger.debug(f"Container '{container}' is healthy.")
                     container_queue.get()
                 elif health_status != "starting":
+                    logger.warning(f"Container '{container}' is not healthy.")
+                    container_logs = run_command(
+                        command=["docker", "logs", container], verbose=False
+                    )
+                    logger.debug(
+                        f"Container logs for '{container}':\n{container_logs.stdout}"
+                    )
                     raise RuntimeError(
                         f"Container '{container}' has unexpected health status: {health_status}."
                     )


### PR DESCRIPTION
currently when a docker container doesn't reach healthy status, only the status is logged but there's no information regarding why the container failed to become healthy. This adds debug logging to unhealthy containers, which will look like the following:
<img width="974" alt="Screenshot 2025-04-28 at 11 19 41 PM" src="https://github.com/user-attachments/assets/aef4eb1f-4d2c-4a51-a3ac-905290650025" />
