### PR TITLE
Run workflows: don't spin up frontend/nginx

### DIFF
--- a/run_workflow.sh
+++ b/run_workflow.sh
@@ -165,13 +165,13 @@ echo "  Use Helm: $USE_HELM"
 
 # 1. Stop existing containers
 echo "Stopping Docker containers..."
-docker compose down
+docker compose down backend
 
 # 2. Start containers in detached mode
 echo "Starting Docker containers..."
 # docker volume create is idempotent
 docker volume create dind-data
-docker compose up -d
+docker compose up -d backend
 
 # 3. Build the python command
 echo "Building Python execution command..."


### PR DESCRIPTION
It's not necessary to do `docker compose up -d`/`down`, since it starts `backend`, `frontend`, and `nginx` + a bit annoying because `nginx` container causes port conflicts with `npm start`, so we can't be reviewing logs and running `run_workflow.sh`

Instead, we only need to spin up `docker compose up -d/down backend`