### PR TITLE
reject submit on no exploit.sh

### DIFF
--- a/agents/detect_agent/detect_agent.py
+++ b/agents/detect_agent/detect_agent.py
@@ -124,13 +124,16 @@ class DetectAgent(BaseAgent):
                     )
                     detect_agent_message.set_message(combined_log)
                     return detect_agent_message
-                detect_agent_message.set_submission(True)
-                self._log("Received submission. Evaluating the exploit...")
 
         if not self.agent_exploit_script.exists():
-            combined_log = self._log("No exploit_files/exploit.sh found.", clear=True)
+            combined_log = self._log("No exploit script detected", clear=True)
             detect_agent_message.set_message(combined_log)
             return detect_agent_message
+
+        # Only set submision = true if exploit script exists
+        if self.submit:
+            self._log("Received submission. Evaluating the exploit...")
+            detect_agent_message.set_submission(True)
 
         if not git_has_changes(self.exploit_files_dir, check_all=False):
             combined_log = self._log(

--- a/agents/exploit_agent/exploit_agent.py
+++ b/agents/exploit_agent/exploit_agent.py
@@ -145,13 +145,15 @@ class ExploitAgent(BaseAgent):
                 if not prev_agent_message.submission:
                     self._log_step("Waiting for submission...")
                     return self._update_exploit_agent_message()
-                else:
-                    self._log_step("Submission received.")
-                    self.last_exploit_agent_message.set_submission(True)
 
         if not self.exploit_script.exists():
-            self._log_step("No exploit.sh found in the exploit_files folder. Skipping.")
+            self._log_step("No exploit script detected")
             return self._update_exploit_agent_message()
+
+        # Only set submision = true if exploit script exists
+        if self.submit:
+            self._log_step("Submission received.")
+            self.last_exploit_agent_message.set_submission(True)
 
         self._log_step("Exploit script found.")
 

--- a/tests/agents/test_detect_agent.py
+++ b/tests/agents/test_detect_agent.py
@@ -132,7 +132,7 @@ async def test_skip_no_exploit(detect_agent, mocker):
         final_msg = await agent.run([init_msg])
 
         # Verify the result
-        assert "No exploit_files/exploit.sh found." in final_msg.message
+        assert "No exploit script detected" in final_msg.message
 
 
 @pytest.mark.asyncio
@@ -170,6 +170,30 @@ async def test_waiting_for_submission(detect_agent, mocker):
 
     # Verify the result
     assert "Waiting for the submission..." in final_msg.message
+
+
+@pytest.mark.asyncio
+async def test_reject_submission_when_no_exploit_script(detect_agent, mocker):
+    """Test that DetectAgent rejects a submission when no exploit script is detected.
+    This should happen even when submit=True and the previous message has submission=True.
+    """
+    # Configure the agent for submissions
+    mocker.patch.object(detect_agent, "submit", True)
+
+    # Create a mock executor agent message with submission=True
+    init_msg = ExecutorAgentMessage(
+        agent_id="executor_agent", message="Test submission message", submission=True
+    )
+
+    # Mock that exploit.sh doesn't exist
+    mocker.patch.object(Path, "exists", return_value=False)
+
+    # Run the agent with the submission message
+    result = await detect_agent.run([init_msg])
+
+    # Verify the agent rejected the submission correctly
+    assert result.submission is False
+    assert "No exploit script detected" in result.message
 
 
 @pytest.mark.asyncio

--- a/tests/agents/test_exploit_agent.py
+++ b/tests/agents/test_exploit_agent.py
@@ -1,5 +1,6 @@
 import shutil
 import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -61,7 +62,34 @@ def mock_resources():
 @pytest.mark.asyncio
 async def test_run_skips_if_no_exploit_script(exploit_agent, mock_prev_message):
     message = await exploit_agent.run([mock_prev_message])
-    assert "No exploit.sh found" in message.message
+    assert "No exploit script detected" in message.message
+
+
+@pytest.mark.asyncio
+async def test_reject_submission_when_no_exploit_script(
+    exploit_agent, mock_prev_message
+):
+    """Test that ExploitAgent rejects a submission when no exploit script is detected.
+    This should happen even when submit=True and the previous message has submission=True.
+    """
+    # Configure the agent for submissions
+    exploit_agent.submit = True
+
+    # Create a mock executor agent message with submission=True
+    from messages.agent_messages.executor_agent_message import ExecutorAgentMessage
+
+    executor_message = ExecutorAgentMessage(
+        agent_id="executor_agent", message="Test submission message", submission=True
+    )
+
+    # Make sure exploit script path returns False when checked for existence
+    with patch.object(Path, "exists", return_value=False):
+        # Run the agent with the submission message
+        result = await exploit_agent.run([executor_message])
+
+        # Verify the agent rejected the submission correctly
+        assert result.submission is False
+        assert "No exploit script detected" in result.message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When the agent attempts to submit with no exploit.sh:

We will return a message "No exploit script detected". 

tested locally pre and post exploit.sh

<img width="1442" alt="Screenshot 2025-04-30 at 10 19 17 AM" src="https://github.com/user-attachments/assets/912211fb-c6e4-4d62-88bf-51cad46f9420" />

<img width="1415" alt="Screenshot 2025-04-30 at 10 21 53 AM" src="https://github.com/user-attachments/assets/3b424767-7898-4c4a-a06e-91c03c82af39" />
