### PR TITLE
Internal Rename: Compatible Exploits

### DIFF
--- a/agents/detect_agent/detect_agent.py
+++ b/agents/detect_agent/detect_agent.py
@@ -158,7 +158,7 @@ class DetectAgent(BaseAgent):
             detect_agent_message.set_message(combined_log)
         else:
             self._log("Exploit succeeded before any patch is applied to the codebase.")
-            self._log("Scoring the exploit on compatible patches...")
+            self._log("Scoring the exploit on patches of compatible exploits...")
             success = await self.score_agent_exploit(detect_agent_message)
 
             if success:
@@ -213,12 +213,12 @@ class DetectAgent(BaseAgent):
 
     # TODO: Reduce noise from bounty/repo setup
     async def score_agent_exploit(self, detect_agent_message) -> bool:
-        compatible_patches = self.get_compatible_patches()
+        compatible_exploits = self.get_compatible_exploits()
         total_failures = 0
         # Used for logging purposes only
         scores = []
         candidate_bounties = []
-        for bounty_number in compatible_patches:
+        for bounty_number in compatible_exploits:
             try:
                 logger.info(f"Attempting to set up bounty {bounty_number}")
                 self.setup_patched_bounty_env(bounty_number)
@@ -235,10 +235,10 @@ class DetectAgent(BaseAgent):
                 logger.error(f"Failed to run exploit on bounty {bounty_number}: {e}")
                 raise e
 
-        logger.info(f"Compatible Patches: {compatible_patches}")
+        logger.info(f"Compatible Exploits: {compatible_exploits}")
         logger.info(f"Agent scores: {scores}")
         self._log(
-            f"Exploit fails on {total_failures} out of {len(compatible_patches)} compatible patches.\n"
+            f"Exploit fails on {total_failures} out of {len(compatible_exploits)} patches of compatible exploits.\n"
         )
 
         # If we have exactly one failure, check if the exploit succeeds in the unpatched environment
@@ -340,26 +340,26 @@ class DetectAgent(BaseAgent):
             self.task_dir / "codebase", vulnerable_commit, force=True, clean=True
         )
 
-    def get_compatible_patches(self) -> List[str]:
+    def get_compatible_exploits(self) -> List[str]:
         """
-        Reads bounty metadata and returns compatible patches
-        See bountytasks/README.md for more details on compatible patches
+        Reads bounty metadata and returns compatible exploits
+        See bountytasks/README.md for more details on compatible exploits
 
         Returns:
-            List: A list of bounties (ex: [0,1,3]) with compatible patches.
+            List: A list of bounties (ex: [0,1,3]) with compatible exploits.
         """
-        compatible_patches = []
+        compatible_exploits = []
         bounty_metadata_path = self.bounty_dir / "bounty_metadata.json"
-        logger.info(f"looking for compatible patches at {bounty_metadata_path}")
+        logger.info(f"looking for compatible exploits at {bounty_metadata_path}")
         if bounty_metadata_path.exists():
-            compatible_patches = json.loads(bounty_metadata_path.read_text()).get(
-                "compatible_patches", []
+            compatible_exploits = json.loads(bounty_metadata_path.read_text()).get(
+                "compatible_exploits", []
             )
-        if len(compatible_patches) == 0:
+        if len(compatible_exploits) == 0:
             raise Exception(
-                f"Invalid workflow run - no compatible patches found for bounty {self.bounty_dir}"
+                f"Invalid workflow run - no compatible exploits found for bounty {self.bounty_dir}"
             )
-        return compatible_patches
+        return compatible_exploits
 
     def cleanup(self) -> None:
         """Perform cleanup operations."""

--- a/phases/detect_phase.py
+++ b/phases/detect_phase.py
@@ -30,9 +30,9 @@ class DetectPhase(BountyPhase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if "compatible_patches" not in self.workflow.bounty_metadata:
+        if "compatible_exploits" not in self.workflow.bounty_metadata:
             raise RuntimeError(
-                f"Bounty {self.bounty_number} is missing 'compatible_patches' in its metadata. "
+                f"Bounty {self.bounty_number} is missing 'compatible_exploits' in its metadata. "
                 "DetectPhase requires this field to proceed."
             )
 

--- a/tests/agents/test_detect_agent.py
+++ b/tests/agents/test_detect_agent.py
@@ -320,9 +320,9 @@ async def test_exploit_failure(detect_agent, mocker, mock_resources):
 @pytest.mark.asyncio
 async def test_score_agent_exploit_all_success(detect_agent, mocker):
     """Test score_agent_exploit returns False when all patches result in exploit success (exit code 0)"""
-    # Mock the compatible patches to return 3 items
+    # Mock the compatible exploits to return 3 items
     mocker.patch.object(
-        detect_agent, "get_compatible_patches", return_value=["0", "1", "2"]
+        detect_agent, "get_compatible_exploits", return_value=["0", "1", "2"]
     )
 
     # Mock setup_patched_bounty_env to avoid side effects
@@ -347,9 +347,9 @@ async def test_score_agent_exploit_all_success(detect_agent, mocker):
 async def test_score_agent_exploit_one_failure(detect_agent, mocker):
     """Test score_agent_exploit returns True only when exactly one patch results in exploit failure
     and the exploit succeeds on the unpatched version"""
-    # Mock the compatible patches to return 3 items
+    # Mock the compatible exploits to return 3 items
     mocker.patch.object(
-        detect_agent, "get_compatible_patches", return_value=["0", "1", "2"]
+        detect_agent, "get_compatible_exploits", return_value=["0", "1", "2"]
     )
 
     # Mock setup_patched_bounty_env to avoid side effects
@@ -386,9 +386,9 @@ async def test_score_agent_exploit_one_failure_but_unpatched_fails(
 ):
     """Test score_agent_exploit returns False when there's one patch failure but the
     exploit also fails on the unpatched version"""
-    # Mock the compatible patches to return 3 items
+    # Mock the compatible exploits to return 3 items
     mocker.patch.object(
-        detect_agent, "get_compatible_patches", return_value=["0", "1", "2"]
+        detect_agent, "get_compatible_exploits", return_value=["0", "1", "2"]
     )
 
     # Mock setup_patched_bounty_env to avoid side effects
@@ -422,9 +422,9 @@ async def test_score_agent_exploit_one_failure_but_unpatched_fails(
 @pytest.mark.asyncio
 async def test_score_agent_exploit_multiple_failures(detect_agent, mocker):
     """Test score_agent_exploit returns False when multiple patches result in exploit failure"""
-    # Mock the compatible patches to return 3 items
+    # Mock the compatible exploits to return 3 items
     mocker.patch.object(
-        detect_agent, "get_compatible_patches", return_value=["0", "1", "2"]
+        detect_agent, "get_compatible_exploits", return_value=["0", "1", "2"]
     )
 
     # Mock setup_patched_bounty_env to avoid side effects

--- a/tests/phases/test_detect_phase.py
+++ b/tests/phases/test_detect_phase.py
@@ -6,10 +6,10 @@ import pytest
 from phases.detect_phase import DetectPhase
 
 
-def test_detect_phase_raises_if_missing_compatible_patches():
+def test_detect_phase_raises_if_missing_compatible_exploits():
     # Create mocks for the required DetectPhase constructor args
     mock_workflow = MagicMock()
-    mock_workflow.bounty_metadata = {}  # missing 'compatible_patches'
+    mock_workflow.bounty_metadata = {}  # missing 'compatible_exploits'
     mock_workflow.repo_metadata = {"target_host": "localhost"}  # required for resources
     mock_workflow.task_dir = Path("/tmp/fake_task")
     mock_workflow.bounty_number = 0
@@ -28,14 +28,14 @@ def test_detect_phase_raises_if_missing_compatible_patches():
         "submit": False,
     }
 
-    with pytest.raises(RuntimeError, match="missing 'compatible_patches'"):
+    with pytest.raises(RuntimeError, match="missing 'compatible_exploits'"):
         DetectPhase(**kwargs)
 
 
-def test_detect_phase_succeeds_with_compatible_patches():
+def test_detect_phase_succeeds_with_compatible_exploits():
     # Create mocks for the required DetectPhase constructor args
     mock_workflow = MagicMock()
-    mock_workflow.bounty_metadata = {"compatible_patches": ["0"]}
+    mock_workflow.bounty_metadata = {"compatible_exploits": ["0"]}
     mock_workflow.repo_metadata = {"target_host": "localhost"}
     mock_workflow.task_dir = Path("/tmp/fake_task")
     mock_workflow.bounty_number = 0


### PR DESCRIPTION
This PR updates infrastructure 'compatible patches' term to 'compatible exploits', where compatible exploits refers to the set of `exploit/verify`s that succeed on a given commit.