### PR TITLE
fix(docker): allow local autobuild of bountyagent Docker image as fallback; move exploit verification into a container

### DIFF
--- a/agents/detect_agent/detect_agent.py
+++ b/agents/detect_agent/detect_agent.py
@@ -29,6 +29,7 @@ from utils.logger import get_main_logger
 SETUP_FILES_DIR = "setup_files"
 logger = get_main_logger(__name__)
 
+DETECT_DOCKER_IMAGE: str = "bountyagent"
 
 @dataclass
 class DetectAgentConfig(AgentConfig):
@@ -418,7 +419,7 @@ bash exploit.sh
 
             agent_exploit_message = DockerActionMessage(
                 resource_id=f"agent_exploit_{self.resources.docker.resource_id}",
-                docker_image="cybench/bountyagent:latest",
+                docker_image=DETECT_DOCKER_IMAGE,
                 command=exploit_command,
                 network="shared_net",
                 volumes=volumes,

--- a/agents/detect_patch_agent/detect_patch_agent.py
+++ b/agents/detect_patch_agent/detect_patch_agent.py
@@ -38,6 +38,7 @@ logger = get_main_logger(__name__)
 INVARIANTS_RETRY = 3
 INVARIANTS_TIMEOUT = 5400  # 90 minutes
 
+DETECT_PATCH_DOCKER_IMAGE: str = "bountyagent"
 
 @dataclass
 class DetectPatchAgentConfig(AgentConfig):
@@ -436,7 +437,7 @@ class DetectPatchAgent(BaseAgent):
 
             exploit_execution = DockerActionMessage(
                 resource_id=f"exploit_{self.resources.docker.resource_id}",
-                docker_image="cybench/bountyagent:latest",
+                docker_image=DETECT_PATCH_DOCKER_IMAGE,
                 command=exploit_command,
                 network="shared_net",
                 work_dir=f"/app/{str(relative_path)}",

--- a/agents/exploit_agent/exploit_agent.py
+++ b/agents/exploit_agent/exploit_agent.py
@@ -27,6 +27,8 @@ from utils.logger import get_main_logger
 
 logger = get_main_logger(__name__)
 
+EXPLOIT_DOCKER_IMAGE: str = "bountyagent"
+VERIFY_DOCKER_IMAGE: str = "bountyagent"
 
 @dataclass
 class ExploitAgentConfig(AgentConfig):
@@ -284,7 +286,7 @@ bash exploit.sh
 
             exploit_message = DockerActionMessage(
                 resource_id=f"exploit_{self.resources.docker.resource_id}",
-                docker_image="cybench/bountyagent:latest",
+                docker_image=EXPLOIT_DOCKER_IMAGE,
                 command=exploit_command,
                 network="shared_net",
                 volumes=volumes,
@@ -326,27 +328,39 @@ bash exploit.sh
 
         return exit_code
 
-    async def _run_verify(self, logging=True):
+    async def _run_verify(self, logging: bool = True) -> int:
+        """
+        Run verify.sh inside a short-lived Docker container, using the same bind-mounted
+        /app workspace as exploit execution.
+        """
         verify_command = "bash verify.sh"
         self.reset_verify_files()
-        # Make the script executable
         self.verify_script.chmod(self.verify_script.stat().st_mode | 0o755)
 
-        verify_result = await run_command_async(
-            verify_command, work_dir=self.verify_files_dir
+        volumes = {
+            str(self.tmp_dir.resolve()): {
+                "bind": "/app",
+                "mode": "rw",
+            }
+        }
+
+        verify_message = DockerActionMessage(
+            resource_id=f"verify_{self.resources.docker.resource_id}",
+            docker_image=VERIFY_DOCKER_IMAGE,
+            command=verify_command,
+            network="shared_net",
+            work_dir="/app/verify_files",
+            volumes=volumes,
+            prev=self.last_action_message,
         )
-        exit_code = verify_result.returncode
+
+        verify_message = await self.resources.docker.run(verify_message)
+        exit_code = verify_message.exit_code if verify_message.exit_code is not None else -1
 
         if logging:
-            verify_message = ScriptActionMessage(
-                resource_id="verify_subprocess",
-                message=f"{verify_result.stdout}\n{verify_result.stderr}",
-                command=verify_command,
-                exit_code=exit_code,
-                prev=self.last_action_message,
-            )
             self._log_step(f"Output from verify.sh: \n{verify_message.message}")
             self._update_exploit_agent_message(verify_message)
+
         return exit_code
 
     @retry(stop=stop_after_attempt(3), wait=wait_fixed(2))

--- a/agents/patch_agent/patch_agent.py
+++ b/agents/patch_agent/patch_agent.py
@@ -33,6 +33,7 @@ from utils.logger import get_main_logger
 
 logger = get_main_logger(__name__)
 
+PATCH_DOCKER_IMAGE: str = "bountyagent"
 
 INVARIANTS_RETRY = 3
 INVARIANTS_TIMEOUT = 5400  # 90 minutes
@@ -321,7 +322,7 @@ class PatchAgent(BaseAgent):
 
             exploit_execution = DockerActionMessage(
                 resource_id=f"exploit_{self.resources.docker.resource_id}",
-                docker_image="cybench/bountyagent:latest",
+                docker_image=PATCH_DOCKER_IMAGE,
                 command=exploit_command,
                 network="shared_net",
                 work_dir=f"/app/{str(relative_path)}",

--- a/resources/docker_image_manager.py
+++ b/resources/docker_image_manager.py
@@ -1,0 +1,217 @@
+import hashlib
+import os
+import threading
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+import docker
+
+DEFAULT_REMOTE_IMAGE: str = "cybench/bountyagent:latest"
+
+# Prevent repeated/concurrent pull/build across retries and/or multiple resources in-process
+_IMAGE_RESOLVE_LOCK = threading.Lock()
+_IMAGE_READY_CACHE: Dict[Tuple[str, str], str] = {}  # (local_tag, platform) -> image_id
+
+
+def _normalize_arch(arch: str) -> str:
+    a = (arch or "").lower()
+    # Common daemon variants vs Docker platform arch names
+    if a in {"x86_64", "x64", "amd64"}:
+        return "amd64"
+    if a in {"aarch64", "arm64"}:
+        return "arm64"
+    return a
+
+
+def _normalize_platform(platform: str) -> str:
+    p = (platform or "").strip()
+    if not p:
+        return "linux/amd64"
+    if "/" not in p:
+        # allow passing just arch
+        return f"linux/{_normalize_arch(p)}"
+    os_name, arch = (p.split("/", 1) + [""])[:2]
+    os_name = (os_name or "linux").lower()
+    arch = _normalize_arch(arch)
+    return f"{os_name}/{arch}"
+
+
+def get_target_platform(client: docker.DockerClient) -> str:
+    """
+    Resolve target platform for docker pull/build by docker daemon info (Architecture)
+    """
+
+    try:
+        info = client.info()
+        arch = (info or {}).get("Architecture") or "amd64"
+        return _normalize_platform(f"linux/{arch}")
+    except Exception:
+        return "linux/amd64"
+
+
+def _get_local_image(client: docker.DockerClient, tag: str):
+    try:
+        return client.images.get(tag)
+    except docker.errors.ImageNotFound:
+        return None
+
+
+def _image_id_still_present(client: docker.DockerClient, image_id: str) -> bool:
+    try:
+        client.images.get(image_id)
+        return True
+    except Exception:
+        return False
+
+
+def _image_matches_platform(image, platform: str) -> bool:
+    """
+    Best-effort platform match using image inspect fields.
+    """
+    platform = _normalize_platform(platform)
+    expected_os, expected_arch = platform.split("/", 1)
+    try:
+        attrs = getattr(image, "attrs", {}) or {}
+        os_name = (attrs.get("Os") or attrs.get("OS") or "").lower()
+        arch = _normalize_arch(attrs.get("Architecture") or "")
+        if expected_os and os_name and os_name != expected_os:
+            return False
+        if expected_arch and arch and arch != expected_arch:
+            return False
+        return True
+    except Exception:
+        # If we can't reliably determine, don't block usage (but we tried).
+        return True
+
+
+def _pull_remote_image_for_platform(
+    client: docker.DockerClient, remote: str, platform: str, logger=None
+):
+    platform = _normalize_platform(platform)
+    if logger:
+        logger.debug(f"Attempting to pull Docker image '{remote}' for platform {platform}")
+    try:
+        # docker-py supports `platform` for pull on newer versions
+        try:
+            client.images.pull(remote, platform=platform)
+        except TypeError:
+            client.images.pull(remote)
+        return _get_local_image(client, remote)
+    except Exception as e:
+        if logger:
+            logger.warning(
+                f"Failed to pull '{remote}' for platform {platform}: {e}. Will fall back to local build."
+            )
+        return None
+
+
+def _build_local_image_from_repo_root(
+    client: docker.DockerClient,
+    local_tag: str,
+    repo_root: Path,
+    platform: str,
+    logger=None,
+):
+    platform = _normalize_platform(platform)
+    dockerfile_path = repo_root / "Dockerfile"
+    if not dockerfile_path.exists():
+        raise FileNotFoundError(f"Dockerfile not found at repo root: {dockerfile_path}")
+
+    dockerfile_sha = hashlib.sha256(dockerfile_path.read_bytes()).hexdigest()
+
+    # If an existing local image is already labeled with this Dockerfile + platform, reuse it.
+    existing = _get_local_image(client, local_tag)
+    if existing:
+        labels = (
+            (getattr(existing, "attrs", {}) or {})
+            .get("Config", {})
+            .get("Labels", {})
+            or {}
+        )
+        if (
+            labels.get("bountybench.dockerfile.sha256") == dockerfile_sha
+            and labels.get("bountybench.platform") == platform
+            and _image_matches_platform(existing, platform)
+        ):
+            return existing
+
+    if logger:
+        logger.debug(
+            f"Building Docker image '{local_tag}' from {dockerfile_path} for platform {platform}"
+        )
+
+    build_kwargs = dict(
+        path=str(repo_root),
+        dockerfile="Dockerfile",
+        tag=local_tag,
+        rm=True,
+        labels={
+            "bountybench.dockerfile.sha256": dockerfile_sha,
+            "bountybench.platform": platform,
+        },
+    )
+    try:
+        image, _logs = client.images.build(platform=platform, **build_kwargs)
+    except TypeError:
+        image, _logs = client.images.build(**build_kwargs)
+    return image
+
+
+def ensure_image_ready(
+    client: docker.DockerClient,
+    local_tag: str,
+    platform: Optional[str] = None,
+    default_remote_image: Optional[str] = DEFAULT_REMOTE_IMAGE,
+    repo_root: Optional[Path] = None,
+    logger=None,
+) -> str:
+    """
+    Ensure `local_tag` exists locally for the target platform.
+
+    Resolution order:
+    - Prefer an existing local `local_tag` that matches the target platform.
+    - Else try pulling DEFAULT_REMOTE_IMAGE constrained to the target platform; if successful, tag it as `local_tag`.
+    - Else build from `repo_root/Dockerfile` and tag as `local_tag`.
+
+    Returns: resolved image id.
+    """
+    logger.info(f"Ensuring image {local_tag} is ready...")
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parents[1]
+    platform = _normalize_platform(platform or get_target_platform(client))
+    cache_key = (local_tag, platform)
+
+    with _IMAGE_RESOLVE_LOCK:
+        cached_id = _IMAGE_READY_CACHE.get(cache_key)
+        if cached_id and _image_id_still_present(client, cached_id):
+            return cached_id
+
+        local = _get_local_image(client, local_tag)
+        if local and _image_matches_platform(local, platform):
+            _IMAGE_READY_CACHE[cache_key] = local.id
+            if logger:
+                logger.info(
+                    f"Using local Docker image '{local_tag}' for platform {platform}: {local.id}"
+                )
+            return local.id
+
+        pulled = _pull_remote_image_for_platform(client, default_remote_image, platform, logger)
+        if pulled and _image_matches_platform(pulled, platform):
+            if default_remote_image != local_tag:
+                pulled.tag(local_tag)
+            _IMAGE_READY_CACHE[cache_key] = pulled.id
+            if logger:
+                logger.info(
+                    f"Using pulled Docker image '{default_remote_image}' tagged as '{local_tag}' for platform {platform}: {pulled.id}"
+                )
+            return pulled.id
+
+        built = _build_local_image_from_repo_root(client, local_tag, repo_root, platform, logger)
+        _IMAGE_READY_CACHE[cache_key] = built.id
+        if logger:
+            logger.info(
+                f"Using locally built Docker image '{local_tag}' for platform {platform}: {built.id}"
+            )
+        return built.id
+
+

--- a/resources/docker_resource.py
+++ b/resources/docker_resource.py
@@ -17,6 +17,7 @@ from docker.errors import (
 
 from messages.action_messages.docker_action_message import DockerActionMessage
 from resources.base_resource import ActionMessage, BaseResourceConfig
+from resources.docker_image_manager import ensure_image_ready
 from resources.runnable_base_resource import RunnableBaseResource
 from utils.logger import get_main_logger
 
@@ -118,6 +119,12 @@ class DockerResource(RunnableBaseResource):
 
         logger.info(f"Running command in Docker: {command}")
         try:
+            ensure_image_ready(
+                client=self.client,
+                local_tag=docker_image,
+                logger=logger,
+            )
+
             container = self.client.containers.run(
                 image=docker_image,
                 command=command,  # Pass command directly without additional formatting


### PR DESCRIPTION
## Fixes #1065

### Description

I don't know if this can be achieved by using the `run_workflow.sh` or `dockerize_run.sh`.

- [x] **What does this PR do?**  
  - Adds/uses a **platform-aware Docker image resolution flow** so running BountyBench on **Debian x86_64 (linux/amd64)** no longer fails with `exec /usr/local/bin/entrypoint.sh: exec format error`.
  - The system now pulls the correct platform variant when possible, and falls back to building a local `bountyagent` image when the remote image is incompatible/unavailable for the host architecture.
  - The exploit is now verified inside a Docker container, instead of the host machine. This resolved problems including platform inconsistency.

- [x] **Why are these changes needed?/Changes made**  
  - **Why**: On Debian x86, pulling `cybench/bountyagent:latest` can result in an **architecture mismatch** (no `linux/amd64` manifest), which causes container startup to fail with `exec format error`. This makes the platform effectively unusable out-of-the-box.  
  - **Changes made**:
    - Detect target platform.
    - Attempt pull constrained to platform (best-effort `client.images.pull(..., platform=...)` when supported by docker-py).
    - Fallback to local build from repo `Dockerfile` when pull fails or platform mismatch is detected.
    - Cache resolved images by `(local_tag, platform)` to avoid repeated pull/build.
    - Fix a bug in 

---

### Checklist (Review before submitting)

- [x] **Unit Tests:**
  - Existing tests cover `DockerResource` behavior (see `tests/resources/test_docker_resource.py`), but there are no dedicated unit tests for the new platform-aware image resolution logic in `docker_image_manager.py`.  
 
- [x] **Documentation:**

- [x] **Peer Review:**
  - The PR must be reviewed by at least one team member before merging.

---

### Linked Issues

- Resolves #1065 
